### PR TITLE
docs: add user walkthrough tutorials (#126)

### DIFF
--- a/docs/tutorials/01-getting-started.md
+++ b/docs/tutorials/01-getting-started.md
@@ -1,0 +1,85 @@
+# Getting Started with Aura Vault
+
+**Estimated time:** 5 minutes  
+**What you'll learn:** How to open the app for the first time, complete the onboarding flow, and orient yourself before making your first transaction.
+
+---
+
+## Prerequisites
+
+Before you begin you need:
+
+- A Stellar-compatible wallet (e.g. Freighter, Lobstr, or any SEP-41-capable wallet)
+- Some XLM for transaction fees (a few lumens is enough)
+- The SEP-41 underlying token that the vault accepts (check the vault's token address in the README)
+- A modern browser (Chrome, Firefox, Edge, or Safari — latest version recommended)
+
+---
+
+## Step 1 — Open the App
+
+Navigate to the Aura Vault URL in your browser. The page loads a single-page application with a header that reads **"Aura Vault"** and three tab buttons: **Deposit**, **Withdraw**, and **Harvest**.
+
+> **Tip:** Bookmark the exact URL right now. Phishing sites often mimic DeFi apps with nearly identical URLs. Always verify you are on the correct domain before connecting your wallet or signing any transaction.
+
+---
+
+## Step 2 — Complete the Onboarding Flow
+
+If this is your first visit (or you have never completed onboarding before), a modal dialog appears automatically over the page. It walks you through five informational steps:
+
+| Step | Title | What it covers |
+|------|-------|----------------|
+| 1 of 5 | Welcome to Aura Vault | Protocol overview — deposit, earn, harvest on-chain |
+| 2 of 5 | Deposit & Earn | How the Deposit tab works and when yield starts accruing |
+| 3 of 5 | Withdraw Anytime | How to reclaim tokens, no lock-up periods |
+| 4 of 5 | Harvest Rewards | How the Harvest tab compounds gains |
+| 5 of 5 | Stay Secure | Key security reminders before you transact |
+
+**Navigation controls inside the modal:**
+
+- **Next** — advance to the next step
+- **Back** — return to the previous step (appears from step 2 onward)
+- **Get Started** — appears on the last step; closes the modal and saves your progress
+- **Skip** — dismisses the modal immediately without going through all steps
+
+A progress bar at the top of the modal shows how far through the five steps you are. The dots below it are clickable — you can jump to any step directly.
+
+Once you click **Get Started** (or **Skip**), the modal closes and the main UI is accessible. The app remembers your choice in browser `localStorage`, so the modal will not reappear on future visits in the same browser.
+
+> **Note:** If you want to see the onboarding flow again later — for example after clearing your browser data — simply clear `localStorage` for the site and refresh.
+
+---
+
+## Step 3 — Understand What You're Looking At
+
+After onboarding the main screen has three sections:
+
+1. **Header** — displays the "Aura Vault" title.
+2. **Tab navigation** — three buttons (`Deposit`, `Withdraw`, `Harvest`) that switch the active panel.
+3. **Active panel** — the form or panel for whichever tab is selected. Deposit is the default.
+
+Each panel loads on demand (lazy-loaded), so you may briefly see a loading skeleton on a slow connection before the form appears.
+
+---
+
+## Step 4 — Connect Your Wallet (Application-Level)
+
+Aura Vault interacts with the Stellar network through your wallet extension. Depending on your wallet:
+
+1. Click the wallet extension icon in your browser toolbar.
+2. Ensure you are on the **Testnet** network if you are experimenting, or **Mainnet** for real funds.
+3. Confirm the wallet is unlocked and shows your public key (starts with `G…`).
+
+Your wallet does not need to be "connected" to the page the same way EVM wallets work — on Stellar/Soroban the wallet signs individual transactions when prompted.
+
+---
+
+## Next Steps
+
+You are ready to use the vault. Continue with:
+
+- [02 — How to Deposit](./02-deposit.md)
+- [03 — How to Withdraw](./03-withdraw.md)
+- [04 — Dashboard Overview](./04-dashboard.md)
+- [05 — Troubleshooting & Security](./05-troubleshooting-and-security.md)

--- a/docs/tutorials/02-deposit.md
+++ b/docs/tutorials/02-deposit.md
@@ -1,0 +1,95 @@
+# How to Deposit into Aura Vault
+
+**Estimated time:** 3 minutes  
+**What you'll learn:** How to deposit underlying tokens into the vault, receive vault shares, and confirm the transaction was successful.
+
+---
+
+## Before You Start
+
+- Complete the [Getting Started](./01-getting-started.md) guide so your wallet is set up and you are on the correct page.
+- Make sure your wallet holds enough of the **underlying token** to deposit. You also need a small amount of XLM to cover network fees.
+- Decide how many tokens you want to deposit. The minimum is any amount greater than zero that results in at least one share being minted (see [How Shares Work](#how-shares-work) below).
+
+---
+
+## Walkthrough
+
+### 1 — Select the Deposit Tab
+
+On the main page, click the **Deposit** tab button in the navigation row. The active tab is highlighted. The Deposit panel loads and shows:
+
+- A heading: **Deposit**
+- A numeric input labelled **Amount**
+- A **Deposit** button
+
+### 2 — Enter an Amount
+
+Click the **Amount** input field (placeholder text shows `0.00`).
+
+Type the number of tokens you want to deposit. For example: `100`
+
+Rules the form enforces:
+- The value must be a number greater than `0`.
+- Decimal values are allowed (the field accepts `step="any"`).
+- If you submit with an empty or invalid value, a red error message appears beneath the field: *"Enter a valid amount greater than 0."* Correct the value and try again.
+
+### 3 — Click Deposit
+
+Click the **Deposit** button. Two things happen immediately:
+
+1. The form is replaced by a **loading skeleton** (three placeholder rows) while the transaction is being processed.
+2. Your wallet extension will prompt you to **review and sign** the transaction. Check:
+   - The contract being called matches the Aura Vault contract address.
+   - The function is `deposit`.
+   - The amount shown matches what you entered.
+
+Approve the transaction in your wallet.
+
+### 4 — Confirm Success
+
+After the transaction is confirmed on-chain (typically a few seconds on Stellar), the loading skeleton disappears and a **green success toast** appears at the bottom of the screen:
+
+> *"Deposited 100 tokens successfully."*
+
+The Amount field resets to empty, ready for another deposit.
+
+If something goes wrong, an **error message** appears in the panel instead of the toast (see [Troubleshooting](./05-troubleshooting-and-security.md)).
+
+---
+
+## How Shares Work
+
+When you deposit, the vault mints **shares** proportional to your contribution:
+
+- **First depositor:** receives shares at a 1:1 ratio (100 tokens → 100 shares).
+- **Subsequent depositors:** receive `floor(amount × total_shares / total_assets)` shares. As yield accrues, the same number of tokens buys fewer shares — but each share is worth more.
+
+Your shares represent your ownership stake in the vault. More shares = larger claim on the vault's total assets when you withdraw.
+
+> **Why might I get fewer shares than tokens I deposited?**  
+> This is expected behaviour. If the vault has already accrued yield, total assets exceed the original deposits, so new deposits buy into a higher-priced pool. Your shares will still redeem for more than you paid in, assuming yield continues to accrue.
+
+> **What is a "ZeroAmount" error?**  
+> If the number of tokens you deposit is so small that the share calculation rounds down to zero, the vault rejects the transaction with `ZeroAmount` (error 5). Deposit a larger amount.
+
+---
+
+## What Happens On-Chain
+
+The `deposit(caller, amount)` function on the vault contract:
+
+1. Verifies the vault is not paused.
+2. Checks the actual on-chain token balance matches `total_deposited` (flash loan guard).
+3. Transfers `amount` tokens from your wallet to the vault.
+4. Calculates and mints shares to your address.
+5. Updates `total_assets` in storage.
+6. Emits a `deposit` event.
+7. Extends storage TTL (keeps your balance record alive on-chain for 30 days).
+
+---
+
+## Next Steps
+
+- [03 — How to Withdraw](./03-withdraw.md) — redeem your shares for tokens
+- [04 — Dashboard Overview](./04-dashboard.md) — check your share balance and vault stats

--- a/docs/tutorials/03-withdraw.md
+++ b/docs/tutorials/03-withdraw.md
@@ -1,0 +1,102 @@
+# How to Withdraw from Aura Vault
+
+**Estimated time:** 3 minutes  
+**What you'll learn:** How to burn vault shares and receive underlying tokens (plus any accrued yield) back to your wallet.
+
+---
+
+## Before You Start
+
+- You must have previously [deposited](./02-deposit.md) and hold vault shares.
+- Know how many shares you want to redeem. You can check your balance using `balance_of` (see [Dashboard Overview](./04-dashboard.md)).
+- Have a small amount of XLM available for network fees.
+
+---
+
+## Walkthrough
+
+### 1 — Select the Withdraw Tab
+
+Click the **Withdraw** tab button in the navigation row. The Withdraw panel loads and shows:
+
+- A heading: **Withdraw**
+- A numeric input labelled **Shares**
+- A **Withdraw** button
+
+### 2 — Enter the Number of Shares to Redeem
+
+Click the **Shares** input field (placeholder text: `0.00`).
+
+Type the number of shares you want to burn. For example: `50`
+
+Validation rules:
+- Must be a number greater than `0`.
+- Decimals are accepted.
+- Leaving the field empty or entering zero displays: *"Enter a valid share amount greater than 0."*
+
+> **How many tokens will I receive?**  
+> The vault calculates: `floor(shares × total_assets / total_shares)`. If the vault has earned yield since your deposit, each share redeems for more than the original deposit price. You receive principal + accrued yield proportional to your shares.
+
+### 3 — Click Withdraw
+
+Click the **Withdraw** button. The form is replaced by a loading skeleton and your wallet prompts you to sign the transaction. Verify:
+
+- Contract address matches Aura Vault.
+- Function is `withdraw`.
+- Share amount matches what you entered.
+
+Approve in your wallet.
+
+### 4 — Confirm Success
+
+Once confirmed on-chain, the loading skeleton disappears and a green toast appears:
+
+> *"Withdrew 50 shares successfully."*
+
+The underlying tokens (plus yield) are now in your wallet. The Shares field resets to empty.
+
+---
+
+## Understanding the Redemption Rate
+
+The token amount you receive depends on the vault's current exchange rate at the time of withdrawal — not the rate at deposit time. This means:
+
+- If yield has been harvested into the vault since your deposit, you receive **more tokens per share** than you put in.
+- If no yield has been added, you receive exactly what your shares were worth at deposit.
+
+There is **no lock-up period**. You can withdraw at any time as long as the vault is not paused.
+
+---
+
+## Common Errors During Withdrawal
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `InsufficientShares` (3) | You entered more shares than you own | Check your balance and enter a lower amount |
+| `InsufficientUnderlying` (4) | Vault cannot cover the redemption | Vault may be temporarily low on liquidity; try a partial withdrawal or wait |
+| `ZeroAmount` (5) | Zero shares entered | Enter a number greater than 0 |
+| `VaultPaused` (11) | Admin has paused the vault | Wait for the vault to be unpaused; check announcements |
+| `BalanceMismatch` (12) | Flash loan guard triggered | Do not retry immediately; report to the team |
+
+---
+
+## What Happens On-Chain
+
+The `withdraw(caller, shares)` function:
+
+1. Verifies the vault is not paused.
+2. Checks the actual on-chain token balance matches `total_deposited` (flash loan guard).
+3. Verifies caller holds enough shares.
+4. Calculates token amount: `floor(shares × total_assets / total_shares)`.
+5. Burns the shares.
+6. Transfers tokens from the vault to your wallet.
+7. Updates `total_assets` in storage.
+8. Emits a `withdraw` event.
+9. Extends storage TTL.
+
+---
+
+## Next Steps
+
+- [04 — Dashboard Overview](./04-dashboard.md) — verify your updated balance after withdrawal
+- [05 — Troubleshooting & Security](./05-troubleshooting-and-security.md) — what to do if something goes wrong

--- a/docs/tutorials/04-dashboard.md
+++ b/docs/tutorials/04-dashboard.md
@@ -1,0 +1,146 @@
+# Dashboard & UI Overview
+
+**Estimated time:** 4 minutes  
+**What you'll learn:** A complete tour of the Aura Vault interface — every element on screen, what it does, and how to use it effectively.
+
+---
+
+## Page Layout
+
+The Aura Vault UI is a single page with four distinct zones:
+
+```
+┌─────────────────────────────────┐
+│  Header: "Aura Vault"           │
+├─────────────────────────────────┤
+│  Tab Nav: Deposit │ Withdraw │ Harvest │
+├─────────────────────────────────┤
+│                                 │
+│  Active Panel (form / harvest)  │
+│                                 │
+└─────────────────────────────────┘
+     [Toast notifications]
+```
+
+---
+
+## Header
+
+The page header contains the application name **"Aura Vault"** and a **"Skip to main content"** link (visible on keyboard focus) for accessibility. There is no wallet connection button in the header — wallet interactions happen at the transaction level when you submit a form.
+
+---
+
+## Tab Navigation
+
+Three tab buttons switch the active panel:
+
+| Tab | What it does |
+|-----|-------------|
+| **Deposit** | Open to deposit tokens and receive vault shares |
+| **Withdraw** | Open to burn shares and redeem underlying tokens |
+| **Harvest** | Open to inject yield tokens into the vault (keeper role) |
+
+The active tab is visually highlighted. Click any tab to switch panels instantly. Each panel loads on demand — a skeleton placeholder appears briefly on a slow connection.
+
+Keyboard users can navigate between tabs using standard browser tab/focus behaviour. The panels use ARIA `role="tabpanel"` and `role="tab"` attributes for screen reader compatibility.
+
+---
+
+## Deposit Panel
+
+**How to open:** Click the **Deposit** tab.
+
+Elements:
+- **Amount field** — numeric input, accepts any positive decimal number. Placeholder: `0.00`.
+- **Inline error** — appears below the field in red if validation fails (e.g. empty or zero value).
+- **Transaction error** — a dismissible error card appears above the submit button if the on-chain call fails. It includes a **Retry** button.
+- **Deposit button** — submits the transaction.
+- **Loading skeleton** — replaces the form while the transaction is in flight.
+
+Refer to [02 — How to Deposit](./02-deposit.md) for a full step-by-step walkthrough.
+
+---
+
+## Withdraw Panel
+
+**How to open:** Click the **Withdraw** tab.
+
+Elements:
+- **Shares field** — numeric input for the number of vault shares to redeem. Placeholder: `0.00`.
+- **Inline error** — shown below the field on invalid input.
+- **Transaction error** — same dismissible card as Deposit, with Retry.
+- **Withdraw button** — submits the transaction.
+- **Loading skeleton** — displayed while the transaction processes.
+
+Refer to [03 — How to Withdraw](./03-withdraw.md) for a full step-by-step walkthrough.
+
+---
+
+## Harvest Panel
+
+**How to open:** Click the **Harvest** tab.
+
+The Harvest panel is for **keepers** — accounts that inject yield into the vault on behalf of all shareholders. Normal depositors do not need to use this tab.
+
+Elements:
+- **Description text** — *"Inject yield into the vault for all shareholders."*
+- **Yield Amount field** — numeric input for the amount of yield tokens to inject. Placeholder: `0.00`.
+- **Inline error** — validation feedback below the field.
+- **Transaction error** — dismissible error card with Retry.
+- **Harvest button** — submits the `harvest` call.
+- **Loading skeleton** — shown during processing.
+
+When a harvest succeeds, the vault's `total_assets` increases without minting new shares. This raises the redemption value of every existing share — all depositors benefit automatically.
+
+> **Keeper requirement:** The `harvest` function requires at least one shareholder to exist (`total_shares > 0`). Attempting to harvest on an empty vault returns `ZeroShares` (error 8).
+
+---
+
+## Toast Notifications
+
+After a successful transaction, a **toast** appears at the bottom of the screen with a green background. Examples:
+
+- *"Deposited 100 tokens successfully."*
+- *"Withdrew 50 shares successfully."*
+- *"Harvested 25 yield tokens."*
+
+Toasts dismiss automatically or can be closed manually. Error conditions show an inline error card in the panel instead of a toast.
+
+---
+
+## Checking Your Balances
+
+The current UI does not display a live balance dashboard. To check your vault share balance or the vault's total assets, use the Stellar CLI or your wallet's contract explorer:
+
+```bash
+# Check your share balance
+stellar contract invoke \
+  --id <contract-id> \
+  --network testnet \
+  -- balance_of \
+  --address <your-address>
+
+# Check total assets in the vault
+stellar contract invoke \
+  --id <contract-id> \
+  --network testnet \
+  -- total_assets
+
+# Check if vault is paused
+stellar contract invoke \
+  --id <contract-id> \
+  --network testnet \
+  -- is_paused
+```
+
+---
+
+## Onboarding Modal
+
+On first visit, a 5-step onboarding modal covers the main UI. It can be dismissed with **Skip** at any time. To re-trigger it, clear the site's `localStorage` in your browser's developer tools (`Application → Local Storage → Clear`).
+
+---
+
+## Next Steps
+
+- [05 — Troubleshooting & Security](./05-troubleshooting-and-security.md) — error codes, common issues, and security practices

--- a/docs/tutorials/05-troubleshooting-and-security.md
+++ b/docs/tutorials/05-troubleshooting-and-security.md
@@ -1,0 +1,158 @@
+# Troubleshooting & Security Best Practices
+
+**Estimated time:** 10 minutes  
+**What you'll learn:** How to diagnose and fix common errors, what every error code means, and how to keep your funds secure.
+
+---
+
+## Error Reference
+
+Every contract error has a numeric code and a variant name. When an error occurs, the UI shows a dismissible error card with a Retry option.
+
+| Code | Variant | What it means | What to do |
+|------|---------|---------------|------------|
+| 1 | `NotInitialized` | Vault has not been initialized yet | Contract was not set up correctly; contact the admin |
+| 2 | `AlreadyInitialized` | `initialize` called more than once | No action needed; this protects against re-initialization |
+| 3 | `InsufficientShares` | You tried to withdraw more shares than you own | Check your balance with `balance_of` and enter a lower amount |
+| 4 | `InsufficientUnderlying` | Vault does not have enough tokens to cover your withdrawal | Try a smaller withdrawal; if the issue persists, contact the admin |
+| 5 | `ZeroAmount` | Deposited amount is zero, or share calculation rounded to zero | Enter a larger amount |
+| 6 | `MathOverflow` | Arithmetic overflow in share formula | The amount entered is extremely large; enter a smaller value |
+| 7 | `InvalidAddress` | Reserved for future address validation | Should not appear in normal usage |
+| 8 | `ZeroShares` | Harvest attempted on an empty vault | The vault has no depositors; wait for a deposit before harvesting |
+| 9 | `UpgradeUnauthorized` | Non-admin tried to upgrade the contract | You do not have admin privileges |
+| 10 | `StorageLayoutMismatch` | On-chain storage layout version does not match upgrade | Contact the admin; do not retry |
+| 11 | `VaultPaused` | A mutating operation was called while the vault is paused | Wait for the admin to unpause the vault; check the project's announcements |
+| 12 | `BalanceMismatch` | Flash loan guard: actual token balance differs from tracked state | Do **not** retry. Stop transacting and contact the admin immediately |
+
+---
+
+## Common Issues
+
+### "Enter a valid amount greater than 0"
+
+This is a client-side validation error — the transaction was never sent. The field is empty, contains text, or contains zero. Type a positive number and try again.
+
+### Transaction spinner never stops
+
+The loading skeleton stays visible while the transaction is in flight. If it does not resolve after 30–60 seconds:
+
+1. Check the [Stellar network status](https://stellar.org/blog) for outages.
+2. Open your browser's developer console (F12 → Console) and look for network errors.
+3. Check that your wallet approved the transaction — some wallets time out silently if not approved quickly.
+4. Refresh the page. The transaction may have succeeded on-chain even if the UI did not update.
+
+### Wallet did not prompt me to sign
+
+- Make sure your wallet extension is installed and unlocked.
+- Check that the wallet is set to the correct network (Testnet or Mainnet to match the contract).
+- Try refreshing the page and submitting again.
+- Some wallets require you to click the extension icon before they respond to page requests.
+
+### I deposited but my shares seem wrong
+
+Share amounts decrease in token-per-share terms as yield accrues — this is expected. See [How Shares Work](./02-deposit.md#how-shares-work). To verify the exact math:
+
+```
+shares_received = floor(amount × total_shares / total_assets)
+```
+
+Run `total_assets` and `total_shares` read calls to get current values, then verify the calculation yourself.
+
+### I withdrew but received fewer tokens than I deposited
+
+This should not happen if yield has been harvested. Check:
+
+1. Whether `harvest` has been called since your deposit (if not, exchange rate is still 1:1 minus any rounding).
+2. Whether you withdrew all your shares or only part of them.
+3. Whether fees apply (check the `FEE_SYSTEM.md` in the project root).
+
+### `BalanceMismatch` error (code 12)
+
+This is the flash loan guard triggering. It means the vault's actual on-chain token balance does not match its internal accounting. **This is a serious anomaly.** Stop all transactions and contact the protocol team immediately. Do not retry.
+
+---
+
+## Security Best Practices
+
+### Protect Your Private Keys
+
+- Never share your private key or seed phrase with anyone, including support staff.
+- Never enter your seed phrase into a website or app.
+- Use a hardware wallet for large amounts.
+- Store your seed phrase offline on paper in a secure location.
+
+### Verify Before You Sign
+
+Every time your wallet prompts you to sign a transaction, check:
+
+1. **Contract address** — confirm it matches the published Aura Vault contract ID. Bookmark the official address.
+2. **Function name** — should be `deposit`, `withdraw`, or `harvest` depending on what you are doing.
+3. **Amount** — confirm it matches what you entered in the UI.
+
+If anything looks wrong, **reject the transaction** and do not retry until you understand what happened.
+
+### Avoid Phishing
+
+- Only access Aura Vault through the bookmarked URL. Never click links in emails, Discord messages, or Twitter/X posts.
+- The official app will **never** ask for your seed phrase or private key.
+- Check the browser address bar every time you open the app. Phishing sites often use domains that differ by one character (e.g. `aura-vau1t.app` vs `aura-vault.app`).
+
+### Use the Correct Network
+
+Testnet and Mainnet are separate. Testnet tokens have no real value. Before depositing real funds:
+
+1. Confirm your wallet is on **Mainnet**.
+2. Confirm the contract ID matches the Mainnet deployment (see `DEPLOYMENT_GUIDE.md`).
+3. Start with a small test deposit before depositing large amounts.
+
+### Understand the Pause Mechanism
+
+The admin can pause the vault at any time, halting all deposits, withdrawals, and harvests. When the vault is paused:
+
+- Your funds are safe — they remain in the vault.
+- You cannot transact until the vault is unpaused.
+- Monitor the project's official channels for announcements.
+
+To check the current pause state:
+
+```bash
+stellar contract invoke \
+  --id <contract-id> \
+  --network mainnet \
+  -- is_paused
+```
+
+### Keep Browser and Extensions Updated
+
+- Always use the latest version of your browser and wallet extension.
+- Enable automatic updates for your wallet.
+- On public or shared computers, never use your real wallet.
+
+### Watch for Suspicious Events
+
+The vault emits a `suspicious` event when a `BalanceMismatch` is detected. If you monitor the vault on-chain, treat this event as an immediate alert. Check the [monitoring setup](../../monitoring/) for Prometheus/Grafana alerting.
+
+---
+
+## Getting Help
+
+If you encounter an issue not covered here:
+
+1. Check `SUPPORT_FAQ.md` in the project root for additional Q&A.
+2. Review open and closed issues in the GitHub repository.
+3. Reach out through the project's official support channel.
+
+When reporting an issue, include:
+- The exact error message or code
+- Your browser and OS
+- The transaction ID if the wallet provided one
+- Steps to reproduce
+
+---
+
+## Related Docs
+
+- [01 — Getting Started](./01-getting-started.md)
+- [02 — How to Deposit](./02-deposit.md)
+- [03 — How to Withdraw](./03-withdraw.md)
+- [04 — Dashboard Overview](./04-dashboard.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,11 @@
+# Aura Vault — User Tutorials
+
+Step-by-step walkthrough guides for every common task.
+
+| # | Tutorial | Time | Topics |
+|---|----------|------|--------|
+| 1 | [Getting Started](./01-getting-started.md) | 5 min | Wallet setup, first visit, onboarding flow |
+| 2 | [How to Deposit](./02-deposit.md) | 3 min | Deposit tokens, receive shares, confirm success |
+| 3 | [How to Withdraw](./03-withdraw.md) | 3 min | Redeem shares, receive tokens + yield |
+| 4 | [Dashboard Overview](./04-dashboard.md) | 4 min | UI tour, all panels and controls explained |
+| 5 | [Troubleshooting & Security](./05-troubleshooting-and-security.md) | 10 min | All error codes, common fixes, security best practices |


### PR DESCRIPTION
Each guide is grounded in the actual source code (onboarding steps, form fields, error variants from errors.rs), cross-linked to the others, and ready
  to embed in a docs site like Docusaurus or GitBook.

closes  #126 