### PR TITLE
feat(#69): add vault operations dashboard and alert rules

### DIFF
--- a/monitoring/grafana/dashboards/vault-operations.json
+++ b/monitoring/grafana/dashboards/vault-operations.json
@@ -1,0 +1,162 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "aura-vault-operations",
+    "title": "Aura Vault - Operations",
+    "tags": ["aura-vault", "vault-ops"],
+    "timezone": "browser",
+    "refresh": "30s",
+    "time": { "from": "now-1h", "to": "now" },
+    "panels": [
+      {
+        "id": 1,
+        "title": "Total Assets (stroops)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "expr": "vault_total_assets",
+            "legendFormat": "Total Assets"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "thresholds": {
+              "steps": [
+                { "color": "red", "value": 0 },
+                { "color": "green", "value": 1 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "Total Shares",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+        "targets": [
+          {
+            "expr": "vault_total_shares",
+            "legendFormat": "Total Shares"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Vault Paused",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "expr": "vault_is_paused",
+            "legendFormat": "Paused"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              { "type": "value", "options": { "0": { "text": "Active", "color": "green" }, "1": { "text": "PAUSED", "color": "red" } } }
+            ]
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Accumulated Fees (stroops)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+        "targets": [
+          {
+            "expr": "vault_total_fees_collected",
+            "legendFormat": "Fees"
+          }
+        ]
+      },
+      {
+        "id": 5,
+        "title": "Deposit Rate",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+        "targets": [
+          {
+            "expr": "rate(vault_deposits_total[5m])",
+            "legendFormat": "Deposits/s"
+          }
+        ],
+        "fieldConfig": { "defaults": { "unit": "ops" } }
+      },
+      {
+        "id": 6,
+        "title": "Withdrawal Rate",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+        "targets": [
+          {
+            "expr": "rate(vault_withdrawals_total[5m])",
+            "legendFormat": "Withdrawals/s"
+          }
+        ],
+        "fieldConfig": { "defaults": { "unit": "ops" } }
+      },
+      {
+        "id": 7,
+        "title": "Share Price (assets / shares)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+        "targets": [
+          {
+            "expr": "vault_total_assets / vault_total_shares",
+            "legendFormat": "Share Price"
+          }
+        ],
+        "fieldConfig": { "defaults": { "unit": "short" } }
+      },
+      {
+        "id": 8,
+        "title": "Harvest Events",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+        "targets": [
+          {
+            "expr": "rate(vault_harvests_total[5m])",
+            "legendFormat": "Harvests/s"
+          }
+        ],
+        "fieldConfig": { "defaults": { "unit": "ops" } }
+      },
+      {
+        "id": 9,
+        "title": "Balance Mismatch Events (flash-loan guard)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+        "targets": [
+          {
+            "expr": "increase(vault_balance_mismatch_total[5m])",
+            "legendFormat": "Mismatches"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "thresholds": { "steps": [{ "color": "green", "value": 0 }, { "color": "red", "value": 1 }] }
+          }
+        }
+      },
+      {
+        "id": 10,
+        "title": "Transaction Failure Rate",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+        "targets": [
+          {
+            "expr": "rate(vault_transactions_total{status=\"failed\"}[5m]) / rate(vault_transactions_total[5m])",
+            "legendFormat": "Failure Rate"
+          }
+        ],
+        "fieldConfig": { "defaults": { "unit": "percentunit" } }
+      }
+    ]
+  }
+}

--- a/monitoring/prometheus/alert.rules.yml
+++ b/monitoring/prometheus/alert.rules.yml
@@ -76,3 +76,59 @@ groups:
         annotations:
           summary: "Vault balance is low"
           description: "Vault XLM balance is below 100 (current: {{ $value }})."
+
+  - name: aura-vault-operations
+    rules:
+      - alert: VaultPaused
+        expr: vault_is_paused == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Vault is paused"
+          description: "The Aura Vault has been paused for more than 5 minutes. Deposits, withdrawals, and harvests are blocked."
+
+      - alert: VaultBalanceMismatch
+        expr: increase(vault_balance_mismatch_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Vault balance mismatch detected (possible flash-loan attack)"
+          description: "The flash-loan guard triggered {{ $value }} time(s) in the last 5 minutes."
+
+      - alert: VaultDepositsStopped
+        expr: rate(vault_deposits_total[15m]) == 0 and vault_total_shares > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No vault deposits in the last 15 minutes"
+          description: "The vault has shares outstanding but no deposits have been recorded recently."
+
+      - alert: VaultSharePriceDrop
+        expr: (vault_total_assets / vault_total_shares) < (vault_total_assets offset 1h / vault_total_shares offset 1h) * 0.95
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Vault share price dropped >5% in 1 hour"
+          description: "Share price has fallen significantly. Current: {{ $value }}."
+
+      - alert: VaultHighFeeAccumulation
+        expr: vault_total_fees_collected > 1000000000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Vault has accumulated large unclaimed fees"
+          description: "Unclaimed fees: {{ $value }} stroops. Consider withdrawing to treasury."
+
+      - alert: VaultTransactionFailureRate
+        expr: rate(vault_transactions_total{status="failed"}[5m]) / rate(vault_transactions_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High vault transaction failure rate"
+          description: "More than 5% of vault transactions are failing (current: {{ $value | humanizePercentage }})."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -4,6 +4,7 @@ global:
 
 rule_files:
   - "alert.rules.yml"
+  - "cdn-alerts.yml"
 
 alerting:
   alertmanagers:


### PR DESCRIPTION
Grafana (monitoring/grafana/dashboards/vault-operations.json):
- 10-panel vault-specific dashboard: total assets, shares, share price, vault paused status, accumulated fees, deposit/withdrawal/harvest rates, balance mismatch events, tx failure rate

Prometheus (monitoring/prometheus/alert.rules.yml):
- aura-vault-operations group with 6 new rules: VaultPaused, VaultBalanceMismatch (instant), VaultDepositsStopped, VaultSharePriceDrop (>5% in 1h), VaultHighFeeAccumulation, VaultTransactionFailureRate (>5%)

prometheus.yml: load cdn-alerts.yml alongside alert.rules.yml

closes #69 