### PR TITLE
feat(#67): improve backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,4 @@
+# ── Stage 1: Build ────────────────────────────────────────────────
 FROM node:22-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
@@ -6,10 +7,24 @@ COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
 
-FROM node:22-alpine
+# ── Stage 2: Production ───────────────────────────────────────────
+FROM node:22-alpine AS runner
 WORKDIR /app
+
+# Security: non-root user
+RUN addgroup --system --gid 1001 appgroup && \
+    adduser --system --uid 1001 --ingroup appgroup appuser
+
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && npm cache clean --force
+
 COPY --from=builder /app/dist ./dist
+
+USER appuser
+
 EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:3001/api/health || exit 1
+
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
- Add non-root appuser/appgroup (uid/gid 1001) to meet security AC
- Two-stage build: builder compiles TS; runner installs prod deps only
- npm cache clean --force to shrink layer size
- HEALTHCHECK on /api/health (30s interval, 5s timeout, 3 retries)
- Aligns with frontend Dockerfile pattern


closes #67 