### PR TITLE
feat: async job queue metrics routes and DB status tracking migration

### DIFF
--- a/backend/migrations/002_create_transaction_jobs.sql
+++ b/backend/migrations/002_create_transaction_jobs.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS transaction_jobs (
+  id TEXT PRIMARY KEY,
+  tx_type TEXT NOT NULL CHECK (tx_type IN ('deposit', 'withdrawal', 'claim')),
+  wallet_address TEXT NOT NULL,
+  amount TEXT NOT NULL,
+  webhook_url TEXT NULL,
+  status TEXT NOT NULL DEFAULT 'waiting'
+    CHECK (status IN ('waiting', 'active', 'completed', 'failed', 'dead')),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  result TEXT NULL,
+  error TEXT NULL,
+  meta JSONB NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tx_jobs_status ON transaction_jobs (status);
+CREATE INDEX IF NOT EXISTS idx_tx_jobs_wallet ON transaction_jobs (wallet_address);
+CREATE INDEX IF NOT EXISTS idx_tx_jobs_created ON transaction_jobs (created_at DESC);
+
+CREATE OR REPLACE FUNCTION touch_tx_jobs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_tx_jobs_updated_at ON transaction_jobs;
+CREATE TRIGGER trg_tx_jobs_updated_at
+BEFORE UPDATE ON transaction_jobs
+FOR EACH ROW EXECUTE FUNCTION touch_tx_jobs_updated_at();
+
+COMMIT;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import { emailRouter } from "./routes/emailRoutes.js";
 import { gasRouter } from "./routes/gasRoutes.js";
 import { yieldRouter } from "./routes/yieldRoutes.js";
 import { startWorker, stopWorker } from "./queue.js";
+import { queueRouter } from "./routes/queueRoutes.js";
 import { warmCache } from "./services/defi.js";
 import { startEmailWorker, stopEmailWorker } from "./services/emailQueue.js";
 
@@ -84,6 +85,7 @@ app.use("/api/email", emailRouter);
 app.use("/api/v1/user/portfolio", authenticate, portfolioRouter);
 app.use("/api/v1/gas", gasRouter);
 app.use("/api/v1/yield", yieldRouter);
+app.use("/api/v1/queue", queueRouter);
 
 app.get("/api/health", async (_req, res) => {
   const redisHealthy = await pingRedis();

--- a/backend/src/routes/queueRoutes.ts
+++ b/backend/src/routes/queueRoutes.ts
@@ -1,0 +1,42 @@
+import { Router } from "express";
+import { queueMetrics, listJobs, getJob, getDeadLetterJobs } from "../queue.js";
+
+export const queueRouter = Router();
+
+/** GET /api/v1/queue/metrics — queue health dashboard */
+queueRouter.get("/metrics", (_req, res) => {
+  res.json(queueMetrics());
+});
+
+/** GET /api/v1/queue/dashboard — extended metrics + recent jobs */
+queueRouter.get("/dashboard", (_req, res) => {
+  const metrics = queueMetrics();
+  const recentCompleted = listJobs("completed").slice(-20);
+  const recentDead = getDeadLetterJobs().slice(-10);
+  const active = listJobs("active");
+  const waiting = listJobs("waiting");
+
+  res.json({
+    metrics,
+    active,
+    waiting: waiting.slice(0, 20),
+    recentCompleted,
+    recentDead,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+/** GET /api/v1/queue/jobs/:id — single job status */
+queueRouter.get("/jobs/:id", (req, res) => {
+  const job = getJob(req.params.id);
+  if (!job) {
+    res.status(404).json({ error: "Job not found" });
+    return;
+  }
+  res.json(job);
+});
+
+/** GET /api/v1/queue/dlq — dead-letter queue */
+queueRouter.get("/dlq", (_req, res) => {
+  res.json(getDeadLetterJobs());
+});


### PR DESCRIPTION
- Add GET /api/v1/queue/metrics — returns waiting/active/completed/dead counts
- Add GET /api/v1/queue/dashboard — extended metrics with recent jobs
- Add GET /api/v1/queue/jobs/:id — single job status lookup
- Add GET /api/v1/queue/dlq — dead-letter queue contents
- Add migration 002_create_transaction_jobs.sql for DB-backed job status tracking
- Register queueRouter in index.ts
closes #64