### PR TITLE
fix: resolve unhandled rejection in API integration tests

### DIFF
--- a/backend/src/routes/__tests__/api.integration.test.ts
+++ b/backend/src/routes/__tests__/api.integration.test.ts
@@ -19,9 +19,14 @@ const fakeRedisClient = {
   quit: vi.fn().mockResolvedValue(undefined),
 };
 
+// disconnectRedis must be a stable function reference — not a vitest mock — so it
+// still resolves after the module registry is torn down (server.close callback fires
+// asynchronously after the test environment is destroyed).
+const stableDisconnect = () => Promise.resolve(undefined);
+
 vi.mock("../../redis.js", () => ({
   pingRedis: vi.fn().mockResolvedValue(true),
-  disconnectRedis: vi.fn().mockResolvedValue(undefined),
+  disconnectRedis: stableDisconnect,
   getRedis: vi.fn().mockReturnValue(fakeRedisClient),
 }));
 
@@ -137,7 +142,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  vi.restoreAllMocks();
+  vi.clearAllMocks();
 });
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
 Fix unhandled rejection in backend API integration tests
  
  Resolves a TypeError: Cannot read properties of undefined (reading 'catch')
  that appeared as an unhandled rejection after every test run. The error fired
  when the Express server's SIGTERM shutdown handler invoked disconnectRedis()
  inside a server.close() callback — after vitest had already destroyed the
  module mock registry.
  
  Changes
  
  - Replaced vi.fn().mockResolvedValue(undefined) for disconnectRedis with a
  stable module-level function reference (() => Promise.resolve(undefined)),
  ensuring the function remains callable after vitest teardown
  - Replaced vi.restoreAllMocks() with vi.clearAllMocks() in afterAll (restore is
  a no-op on factory mocks and was misleading)
  
  Test results
  
  - 117 tests pass, 0 failures, 0 unhandled errors
  - Covers all /api/v1/* endpoints, auth, email, queue, withdrawal, and
  performance benchmarks
  - All blockchain/Soroban interactions mocked (no live network calls)
  
closes #18  