### PR TITLE
feat(infra): #511 configure Kubernetes NetworkPolicies for zero-trust

### DIFF
--- a/k8s/network-policies/00-default-deny.yaml
+++ b/k8s/network-policies/00-default-deny.yaml
@@ -1,0 +1,23 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# 00-default-deny.yaml
+#
+# Zero-trust baseline: deny ALL ingress and egress for every pod in the
+# aura-vault namespace.  Subsequent policies open only the minimum required
+# paths.  Order of application doesn't matter — Kubernetes merges all
+# NetworkPolicy rules as a union (additive).
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: aura-vault
+  labels:
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/part-of: aura-vault
+spec:
+  # Empty podSelector selects ALL pods in the namespace
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  # No ingress/egress rules → everything is denied by default

--- a/k8s/network-policies/01-frontend-policy.yaml
+++ b/k8s/network-policies/01-frontend-policy.yaml
@@ -1,0 +1,61 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# 01-frontend-policy.yaml
+#
+# Frontend (Next.js) rules:
+#   Ingress  – accept traffic from the ingress controller only (port 3000)
+#   Egress   – reach the backend only (port 4000)
+#              reach kube-dns for name resolution (UDP/TCP 53)
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: frontend-policy
+  namespace: aura-vault
+  labels:
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/part-of: aura-vault
+spec:
+  podSelector:
+    matchLabels:
+      app: frontend
+
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Allow traffic from the ingress-nginx controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3000
+
+  egress:
+    # Allow outbound to the backend on its HTTP port
+    - to:
+        - podSelector:
+            matchLabels:
+              app: backend
+      ports:
+        - protocol: TCP
+          port: 4000
+
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/k8s/network-policies/02-backend-policy.yaml
+++ b/k8s/network-policies/02-backend-policy.yaml
@@ -1,0 +1,96 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# 02-backend-policy.yaml
+#
+# Backend (Node/TS API) rules:
+#   Ingress  – accept traffic from frontend (port 4000)
+#              accept scrape traffic from monitoring namespace (port 9090/metrics)
+#   Egress   – reach PostgreSQL (port 5432)
+#              reach Redis       (port 6379)
+#              reach Horizon API externally (HTTPS 443)
+#              reach kube-dns    (UDP/TCP 53)
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backend-policy
+  namespace: aura-vault
+  labels:
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/part-of: aura-vault
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Accept requests from the frontend
+    - from:
+        - podSelector:
+            matchLabels:
+              app: frontend
+      ports:
+        - protocol: TCP
+          port: 4000
+
+    # Accept Prometheus scrapes from the monitoring namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 9090   # /metrics endpoint
+
+  egress:
+    # PostgreSQL
+    - to:
+        - podSelector:
+            matchLabels:
+              app: postgres
+      ports:
+        - protocol: TCP
+          port: 5432
+
+    # Redis
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - protocol: TCP
+          port: 6379
+
+    # Horizon API (Stellar) — external HTTPS
+    # Restrict to CIDR ranges of horizon.stellar.org / testnet
+    # Keep the CIDR wide for now; tighten once static IPs are known.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/k8s/network-policies/03-postgres-policy.yaml
+++ b/k8s/network-policies/03-postgres-policy.yaml
@@ -1,0 +1,46 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# 03-postgres-policy.yaml
+#
+# PostgreSQL rules:
+#   Ingress – accept connections from backend only (port 5432)
+#   Egress  – DNS only (no outbound data access)
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-policy
+  namespace: aura-vault
+  labels:
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/part-of: aura-vault
+spec:
+  podSelector:
+    matchLabels:
+      app: postgres
+
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: backend
+      ports:
+        - protocol: TCP
+          port: 5432
+
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/k8s/network-policies/04-redis-policy.yaml
+++ b/k8s/network-policies/04-redis-policy.yaml
@@ -1,0 +1,46 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# 04-redis-policy.yaml
+#
+# Redis rules:
+#   Ingress – accept connections from backend only (port 6379)
+#   Egress  – DNS only
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-policy
+  namespace: aura-vault
+  labels:
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/part-of: aura-vault
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: backend
+      ports:
+        - protocol: TCP
+          port: 6379
+
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/k8s/network-policies/05-monitoring-policy.yaml
+++ b/k8s/network-policies/05-monitoring-policy.yaml
@@ -1,0 +1,126 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# 05-monitoring-policy.yaml
+#
+# Monitoring namespace rules — lives in the monitoring namespace, not
+# aura-vault, so it also needs to be applied there.
+#
+# Prometheus rules:
+#   Egress – scrape /metrics on all pods in aura-vault namespace (port 9090)
+#            reach Alertmanager (port 9093)
+#            DNS
+#   Ingress – Grafana to query Prometheus (port 9090)
+#             ingress-nginx for UI access
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Allow Prometheus to scrape all aura-vault pods on the metrics port ────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-scrape-aura-vault
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/part-of: aura-vault
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+
+  policyTypes:
+    - Egress
+
+  egress:
+    # Scrape aura-vault namespace — /metrics on port 9090
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: aura-vault
+      ports:
+        - protocol: TCP
+          port: 9090   # backend metrics
+        - protocol: TCP
+          port: 3000   # frontend metrics (if exposed)
+
+    # Alertmanager
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: alertmanager
+      ports:
+        - protocol: TCP
+          port: 9093
+
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+---
+# ── Allow Grafana to query Prometheus ─────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-to-prometheus
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/part-of: aura-vault
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+      ports:
+        - protocol: TCP
+          port: 9090
+
+---
+# ── Allow aura-vault pods to receive scrape traffic from monitoring ns ─────────
+# (companion rule on the aura-vault side — mirrors 02-backend-policy ingress)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-scrape
+  namespace: aura-vault
+  labels:
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/part-of: aura-vault
+spec:
+  # Target all pods that expose metrics
+  podSelector:
+    matchLabels:
+      prometheus.io/scrape: "true"
+
+  policyTypes:
+    - Ingress
+
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 9090
+        - protocol: TCP
+          port: 3000

--- a/scripts/test-network-policies.sh
+++ b/scripts/test-network-policies.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# scripts/test-network-policies.sh
+#
+# Validates Kubernetes NetworkPolicies by running kubectl exec probes from
+# pods that SHOULD be blocked to confirm deny-all is working, and from pods
+# that SHOULD have access to confirm the allow rules are correct.
+#
+# Usage:
+#   ./scripts/test-network-policies.sh [--namespace aura-vault]
+#
+# Prerequisites:
+#   - kubectl configured and pointing at the correct cluster/context
+#   - Network policies applied: kubectl apply -f k8s/network-policies/
+#   - Pods running in aura-vault and monitoring namespaces
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+NS="${1:-aura-vault}"
+PASS=0
+FAIL=0
+SKIP=0
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+green() { echo -e "\033[32m✓ $*\033[0m"; }
+red()   { echo -e "\033[31m✗ $*\033[0m"; }
+yellow(){ echo -e "\033[33m~ $*\033[0m"; }
+
+# expect_blocked: test that a connection is REFUSED/TIMEOUT (policy working)
+expect_blocked() {
+  local label="$1" pod="$2" target_host="$3" target_port="$4"
+  echo -n "  [BLOCKED expected] ${label} ... "
+
+  if kubectl exec -n "${NS}" "${pod}" -- \
+       timeout 5 bash -c "echo > /dev/tcp/${target_host}/${target_port}" \
+       2>/dev/null; then
+    red "FAIL — connection succeeded (policy not enforced!)"
+    ((FAIL++))
+  else
+    green "PASS — connection blocked as expected"
+    ((PASS++))
+  fi
+}
+
+# expect_allowed: test that a connection SUCCEEDS (policy not too restrictive)
+expect_allowed() {
+  local label="$1" pod="$2" target_host="$3" target_port="$4"
+  echo -n "  [ALLOWED expected] ${label} ... "
+
+  if kubectl exec -n "${NS}" "${pod}" -- \
+       timeout 5 bash -c "echo > /dev/tcp/${target_host}/${target_port}" \
+       2>/dev/null; then
+    green "PASS — connection allowed as expected"
+    ((PASS++))
+  else
+    red "FAIL — connection blocked (policy too restrictive!)"
+    ((FAIL++))
+  fi
+}
+
+# skip if pod not found
+get_pod() {
+  kubectl get pods -n "${NS}" -l "app=$1" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo ""
+}
+
+echo "═══════════════════════════════════════════════════════════"
+echo " Aura Vault NetworkPolicy Validation"
+echo " Namespace: ${NS}"
+echo "═══════════════════════════════════════════════════════════"
+
+# ── Resolve pod names ─────────────────────────────────────────────────────────
+FRONTEND_POD=$(get_pod frontend)
+BACKEND_POD=$(get_pod backend)
+POSTGRES_POD=$(get_pod postgres)
+REDIS_POD=$(get_pod redis)
+
+for pod_var in FRONTEND_POD BACKEND_POD POSTGRES_POD REDIS_POD; do
+  if [[ -z "${!pod_var}" ]]; then
+    yellow "SKIP — ${pod_var} not found in namespace ${NS}"
+    ((SKIP++))
+  fi
+done
+
+echo ""
+echo "── 1. Default-deny: frontend should NOT reach postgres directly ──"
+if [[ -n "${FRONTEND_POD}" && -n "${POSTGRES_POD}" ]]; then
+  PG_IP=$(kubectl get pod -n "${NS}" "${POSTGRES_POD}" -o jsonpath='{.status.podIP}')
+  expect_blocked "frontend → postgres:5432" "${FRONTEND_POD}" "${PG_IP}" "5432"
+else
+  yellow "SKIP — pods not available"
+fi
+
+echo ""
+echo "── 2. Default-deny: frontend should NOT reach redis directly ──"
+if [[ -n "${FRONTEND_POD}" && -n "${REDIS_POD}" ]]; then
+  REDIS_IP=$(kubectl get pod -n "${NS}" "${REDIS_POD}" -o jsonpath='{.status.podIP}')
+  expect_blocked "frontend → redis:6379" "${FRONTEND_POD}" "${REDIS_IP}" "6379"
+else
+  yellow "SKIP — pods not available"
+fi
+
+echo ""
+echo "── 3. Backend should reach postgres ──"
+if [[ -n "${BACKEND_POD}" && -n "${POSTGRES_POD}" ]]; then
+  PG_IP=$(kubectl get pod -n "${NS}" "${POSTGRES_POD}" -o jsonpath='{.status.podIP}')
+  expect_allowed "backend → postgres:5432" "${BACKEND_POD}" "${PG_IP}" "5432"
+else
+  yellow "SKIP — pods not available"
+fi
+
+echo ""
+echo "── 4. Backend should reach redis ──"
+if [[ -n "${BACKEND_POD}" && -n "${REDIS_POD}" ]]; then
+  REDIS_IP=$(kubectl get pod -n "${NS}" "${REDIS_POD}" -o jsonpath='{.status.podIP}')
+  expect_allowed "backend → redis:6379" "${BACKEND_POD}" "${REDIS_IP}" "6379"
+else
+  yellow "SKIP — pods not available"
+fi
+
+echo ""
+echo "── 5. Frontend should reach backend ──"
+if [[ -n "${FRONTEND_POD}" && -n "${BACKEND_POD}" ]]; then
+  BE_IP=$(kubectl get pod -n "${NS}" "${BACKEND_POD}" -o jsonpath='{.status.podIP}')
+  expect_allowed "frontend → backend:4000" "${FRONTEND_POD}" "${BE_IP}" "4000"
+else
+  yellow "SKIP — pods not available"
+fi
+
+echo ""
+echo "── 6. Postgres should NOT reach backend (no egress besides DNS) ──"
+if [[ -n "${POSTGRES_POD}" && -n "${BACKEND_POD}" ]]; then
+  BE_IP=$(kubectl get pod -n "${NS}" "${BACKEND_POD}" -o jsonpath='{.status.podIP}')
+  expect_blocked "postgres → backend:4000" "${POSTGRES_POD}" "${BE_IP}" "4000"
+else
+  yellow "SKIP — pods not available"
+fi
+
+echo ""
+echo "── 7. Prometheus (monitoring ns) should scrape backend metrics ──"
+PROMETHEUS_POD=$(kubectl get pods -n monitoring -l "app.kubernetes.io/name=prometheus" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+if [[ -n "${PROMETHEUS_POD}" && -n "${BACKEND_POD}" ]]; then
+  BE_IP=$(kubectl get pod -n "${NS}" "${BACKEND_POD}" -o jsonpath='{.status.podIP}')
+  echo -n "  [ALLOWED expected] prometheus → backend:9090 ... "
+  if kubectl exec -n monitoring "${PROMETHEUS_POD}" -- \
+       timeout 5 bash -c "echo > /dev/tcp/${BE_IP}/9090" 2>/dev/null; then
+    green "PASS — Prometheus can scrape backend"
+    ((PASS++))
+  else
+    red "FAIL — Prometheus cannot scrape backend"
+    ((FAIL++))
+  fi
+else
+  yellow "SKIP — prometheus pod not found in monitoring namespace"
+  ((SKIP++))
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════════════════"
+echo " Results: ${PASS} passed | ${FAIL} failed | ${SKIP} skipped"
+echo "═══════════════════════════════════════════════════════════"
+
+[[ "${FAIL}" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
- 00-default-deny.yaml: deny all ingress+egress for every pod in aura-vault ns
- 01-frontend-policy.yaml: frontend ← ingress-nginx only; → backend:4000 + DNS
- 02-backend-policy.yaml: backend ← frontend + Prometheus; → postgres, redis, Horizon HTTPS (443), DNS
- 03-postgres-policy.yaml: accepts only backend:5432; egress DNS only
- 04-redis-policy.yaml: accepts only backend:6379; egress DNS only
- 05-monitoring-policy.yaml: Prometheus scrapes aura-vault pods on /metrics; Grafana → Prometheus; allow-monitoring-scrape rule on aura-vault side
- scripts/test-network-policies.sh: validates allow/block rules via kubectl exec

closes #511 