### PR TITLE
feat(infra): set up CloudFront CDN with custom caching policies (#507)

### DIFF
--- a/infra/cloudfront/README.md
+++ b/infra/cloudfront/README.md
@@ -1,0 +1,107 @@
+# CloudFront CDN — Aura Vault Protocol
+
+Terraform configuration for a CloudFront distribution that serves the Aura Vault Protocol frontend with optimised per-content-type caching.
+
+## Architecture
+
+```
+User → CloudFront (HTTPS, TLS 1.2+)
+          │
+          ├─ /api/*          → No cache  → Origin (ALB / backend)
+          ├─ *.js *.css ...  → 1 year    → Origin (hashed filenames)
+          ├─ _next/static/*  → 1 year    → Origin (Next.js build output)
+          └─ default (HTML)  → 5 min SWR → Origin
+```
+
+## Cache Policies
+
+| Policy | TTL | Response Header | Applies To |
+|--------|-----|----------------|------------|
+| `static-assets` | 1 year (31,536,000 s) | `Cache-Control: public, max-age=31536000, immutable` | `*.js`, `*.css`, `*.woff2`, `*.png`, `*.ico`, etc. + `_next/static/*` |
+| `html-pages` | 5 min (300 s) | `Cache-Control: public, max-age=300, stale-while-revalidate=60` | Default (all HTML) |
+| `api-bypass` | 0 s | — | `/api/*` |
+
+Static assets are safe to cache for 1 year because Next.js appends a content hash to every filename (`_next/static/chunks/main-abc123.js`). The URL changes on every build, so cached files are always fresh.
+
+`stale-while-revalidate=60` on HTML lets CloudFront serve a slightly stale page for up to 60 seconds while refreshing in the background — eliminating the latency spike at the 5-minute TTL boundary.
+
+## Prerequisites
+
+- Terraform ≥ 1.5
+- AWS provider ~> 5.0
+- An ACM certificate in **us-east-1** covering your domain aliases (CloudFront requires us-east-1 regardless of origin region)
+- AWS credentials with permissions: `cloudfront:*`, `ssm:PutParameter`, `ssm:GetParameter`
+
+## Deployment
+
+```bash
+cd infra/cloudfront
+
+# Initialise Terraform
+terraform init
+
+# Review the plan
+terraform plan \
+  -var="origin_domain_name=alb.internal.example.com" \
+  -var="acm_certificate_arn=arn:aws:acm:us-east-1:123456789012:certificate/..." \
+  -var="domain_aliases=[\"app.auravault.io\"]"
+
+# Apply
+terraform apply \
+  -var="origin_domain_name=alb.internal.example.com" \
+  -var="acm_certificate_arn=arn:aws:acm:us-east-1:123456789012:certificate/..." \
+  -var="domain_aliases=[\"app.auravault.io\"]"
+```
+
+After apply, note the `distribution_id` output — store it as a repository secret named `CLOUDFRONT_DISTRIBUTION_ID`.
+
+## Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `origin_domain_name` | ✅ | — | Domain of the origin server |
+| `acm_certificate_arn` | ✅ | — | ACM certificate ARN (us-east-1) |
+| `domain_aliases` | — | `[]` | Custom domains (e.g. `app.auravault.io`) |
+| `environment` | — | `production` | Used in resource names |
+| `project_name` | — | `aura-vault` | Used in resource names |
+| `price_class` | — | `PriceClass_100` | Coverage: 100=US+EU, 200=+Asia, All=global |
+| `web_acl_id` | — | `null` | Optional WAF Web ACL ARN |
+
+## Triggering Cache Invalidation on Deploy
+
+The `invalidation.sh` script invalidates all paths (`/*`) after every deploy. It requires `cloudfront:CreateInvalidation` permission and the distribution ID.
+
+### Manually
+
+```bash
+export DISTRIBUTION_ID=$(terraform output -raw distribution_id)
+./infra/cloudfront/invalidation.sh
+```
+
+### In GitHub Actions
+
+Add to your deploy job after the build+upload step:
+
+```yaml
+- name: Invalidate CloudFront cache
+  run: bash infra/cloudfront/invalidation.sh
+  env:
+    DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    AWS_DEFAULT_REGION: us-east-1
+```
+
+## Cache Hit Ratio
+
+After a warm-up period (first request to each edge location), expect >90% cache hit ratio for static asset traffic. You can monitor this in CloudFront metrics:
+
+- CloudWatch metric: `CacheHitRate` on the distribution
+- CloudFront console → Distribution → Reports & analytics → Cache statistics
+
+## Security
+
+- All HTTP traffic is redirected to HTTPS via `redirect-to-https` viewer protocol policy.
+- Minimum TLS version: **TLSv1.2_2021** (disables TLS 1.0, 1.1, and older cipher suites).
+- HSTS header (`max-age=63072000; includeSubDomains; preload`) injected by a CloudFront Function on every response.
+- A random origin secret is shared between CloudFront and the origin (stored in SSM Parameter Store). Configure your origin to reject requests missing the `X-CloudFront-Secret` header to prevent direct-to-origin access.

--- a/infra/cloudfront/cache-policies.tf
+++ b/infra/cloudfront/cache-policies.tf
@@ -1,0 +1,125 @@
+# ---------------------------------------------------------------------------
+# CloudFront Cache Policies
+# Three distinct policies covering the three content categories:
+#   1. static-assets  — JS, CSS, fonts, images → 1 year + immutable
+#   2. html-pages     — HTML documents → 5 minutes + stale-while-revalidate
+#   3. api-bypass     — /api/* → no caching, pass through to origin
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudfront_cache_policy" "static_assets" {
+  name        = "${var.project_name}-${var.environment}-static-assets"
+  comment     = "Cache versioned static assets (JS, CSS, fonts, images) for 1 year. These files are content-addressed and never change at a given URL."
+  default_ttl = 31536000 # 1 year in seconds
+  max_ttl     = 31536000
+  min_ttl     = 31536000
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+    enable_accept_encoding_gzip   = true
+    enable_accept_encoding_brotli = true
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "static_assets_headers" {
+  name    = "${var.project_name}-${var.environment}-static-assets-headers"
+  comment = "Adds Cache-Control: max-age=31536000, immutable to static asset responses."
+
+  custom_headers_config {
+    items {
+      header   = "Cache-Control"
+      value    = "public, max-age=31536000, immutable"
+      override = true
+    }
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "html_pages" {
+  name        = "${var.project_name}-${var.environment}-html-pages"
+  comment     = "Cache HTML pages for 5 minutes with stale-while-revalidate allowing background refresh."
+  default_ttl = 300 # 5 minutes
+  max_ttl     = 300
+  min_ttl     = 0
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+    enable_accept_encoding_gzip   = true
+    enable_accept_encoding_brotli = true
+  }
+}
+
+resource "aws_cloudfront_response_headers_policy" "html_pages_headers" {
+  name    = "${var.project_name}-${var.environment}-html-pages-headers"
+  comment = "Adds Cache-Control: max-age=300, stale-while-revalidate=60 to HTML responses."
+
+  custom_headers_config {
+    items {
+      header   = "Cache-Control"
+      value    = "public, max-age=300, stale-while-revalidate=60"
+      override = true
+    }
+  }
+}
+
+# API bypass — zero TTL, all query strings and headers forwarded
+resource "aws_cloudfront_cache_policy" "api_bypass" {
+  name        = "${var.project_name}-${var.environment}-api-bypass"
+  comment     = "Disables caching for /api/* routes. All requests pass through to the origin."
+  default_ttl = 0
+  max_ttl     = 0
+  min_ttl     = 0
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "all"
+    }
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = [
+          "Authorization",
+          "Origin",
+          "Accept",
+          "Content-Type",
+        ]
+      }
+    }
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+    enable_accept_encoding_gzip   = false
+    enable_accept_encoding_brotli = false
+  }
+}
+
+resource "aws_cloudfront_origin_request_policy" "api_forward_all" {
+  name    = "${var.project_name}-${var.environment}-api-forward-all"
+  comment = "Forwards all headers, cookies, and query strings to origin for API requests."
+
+  cookies_config {
+    cookie_behavior = "all"
+  }
+
+  headers_config {
+    header_behavior = "allViewer"
+  }
+
+  query_strings_config {
+    query_string_behavior = "all"
+  }
+}

--- a/infra/cloudfront/invalidation.sh
+++ b/infra/cloudfront/invalidation.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# invalidation.sh — Trigger a CloudFront cache invalidation for all paths.
+#
+# Usage:
+#   ./invalidation.sh <distribution-id>
+#   DISTRIBUTION_ID=EXAMPLEID ./invalidation.sh
+#
+# Required environment / AWS credentials:
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION
+#   (or an IAM role with cloudfront:CreateInvalidation permission)
+#
+# In GitHub Actions, set DISTRIBUTION_ID as a repository secret and call:
+#   - name: Invalidate CloudFront cache
+#     run: infra/cloudfront/invalidation.sh
+#     env:
+#       DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+
+set -euo pipefail
+
+DISTRIBUTION_ID="${1:-${DISTRIBUTION_ID:-}}"
+
+if [[ -z "$DISTRIBUTION_ID" ]]; then
+  echo "ERROR: CloudFront distribution ID is required." >&2
+  echo "  Pass it as the first argument or set the DISTRIBUTION_ID environment variable." >&2
+  exit 1
+fi
+
+echo "Creating CloudFront invalidation for distribution: $DISTRIBUTION_ID"
+
+INVALIDATION_ID=$(aws cloudfront create-invalidation \
+  --distribution-id "$DISTRIBUTION_ID" \
+  --paths "/*" \
+  --query 'Invalidation.Id' \
+  --output text)
+
+echo "Invalidation created: $INVALIDATION_ID"
+echo "Waiting for invalidation to complete..."
+
+aws cloudfront wait invalidation-completed \
+  --distribution-id "$DISTRIBUTION_ID" \
+  --id "$INVALIDATION_ID"
+
+echo "Invalidation $INVALIDATION_ID completed successfully."

--- a/infra/cloudfront/main.tf
+++ b/infra/cloudfront/main.tf
@@ -1,0 +1,204 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = merge(
+      {
+        Project     = var.project_name
+        Environment = var.environment
+        ManagedBy   = "terraform"
+      },
+      var.tags
+    )
+  }
+}
+
+locals {
+  # Static asset file extensions matched by path-pattern cache behaviors
+  static_path_patterns = [
+    "*.js",
+    "*.css",
+    "*.woff",
+    "*.woff2",
+    "*.ttf",
+    "*.eot",
+    "*.png",
+    "*.jpg",
+    "*.jpeg",
+    "*.gif",
+    "*.svg",
+    "*.ico",
+    "*.webp",
+    "*.avif",
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# CloudFront Distribution
+# ---------------------------------------------------------------------------
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.project_name} ${var.environment} frontend CDN"
+  price_class         = var.price_class
+  aliases             = var.domain_aliases
+  web_acl_id          = var.web_acl_id
+  http_version        = "http2and3"
+  wait_for_deployment = false
+
+  # ----- Origin -----
+  origin {
+    domain_name = var.origin_domain_name
+    origin_id   = var.origin_id
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+
+    custom_header {
+      name  = "X-CloudFront-Secret"
+      value = random_password.origin_secret.result
+    }
+  }
+
+  # ----- Default cache behavior (HTML pages / SWR) -----
+  default_cache_behavior {
+    target_origin_id       = var.origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id            = aws_cloudfront_cache_policy.html_pages.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.html_pages_headers.id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.security_headers.arn
+    }
+  }
+
+  # ----- Static assets — one ordered_cache_behavior per extension -----
+  dynamic "ordered_cache_behavior" {
+    for_each = local.static_path_patterns
+    content {
+      path_pattern           = ordered_cache_behavior.value
+      target_origin_id       = var.origin_id
+      viewer_protocol_policy = "redirect-to-https"
+      allowed_methods        = ["GET", "HEAD"]
+      cached_methods         = ["GET", "HEAD"]
+      compress               = true
+
+      cache_policy_id            = aws_cloudfront_cache_policy.static_assets.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.static_assets_headers.id
+    }
+  }
+
+  # ----- Next.js _next/static assets -----
+  ordered_cache_behavior {
+    path_pattern           = "_next/static/*"
+    target_origin_id       = var.origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    cache_policy_id            = aws_cloudfront_cache_policy.static_assets.id
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.static_assets_headers.id
+  }
+
+  # ----- API routes — bypass cache, forward to origin -----
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    target_origin_id       = var.origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = false
+
+    cache_policy_id          = aws_cloudfront_cache_policy.api_bypass.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.api_forward_all.id
+  }
+
+  # ----- TLS -----
+  viewer_certificate {
+    acm_certificate_arn      = var.acm_certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  # ----- Geo restriction (none by default) -----
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  # ----- Access logging (optional, enable by providing a log bucket) -----
+  # Uncomment to enable access logging:
+  # logging_config {
+  #   include_cookies = false
+  #   bucket          = "${aws_s3_bucket.cf_logs.bucket_domain_name}"
+  #   prefix          = "${var.project_name}/${var.environment}/"
+  # }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-cf"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# CloudFront Function — security headers injected at viewer-request
+# ---------------------------------------------------------------------------
+resource "aws_cloudfront_function" "security_headers" {
+  name    = "${var.project_name}-${var.environment}-security-headers"
+  runtime = "cloudfront-js-2.0"
+  comment = "Injects security headers (HSTS, CSP, X-Frame-Options) on every response."
+  publish = true
+
+  code = <<-EOF
+    function handler(event) {
+      var response = event.response;
+      var headers = response.headers;
+      headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubDomains; preload' };
+      headers['x-content-type-options']    = { value: 'nosniff' };
+      headers['x-frame-options']           = { value: 'DENY' };
+      headers['x-xss-protection']          = { value: '1; mode=block' };
+      headers['referrer-policy']           = { value: 'strict-origin-when-cross-origin' };
+      return response;
+    }
+  EOF
+}
+
+# ---------------------------------------------------------------------------
+# Random secret shared with origin to verify requests come from CloudFront
+# ---------------------------------------------------------------------------
+resource "random_password" "origin_secret" {
+  length  = 32
+  special = false
+}
+
+resource "aws_ssm_parameter" "origin_secret" {
+  name        = "/${var.project_name}/${var.environment}/cloudfront/origin-secret"
+  description = "Shared secret between CloudFront and the origin to reject direct-to-origin requests."
+  type        = "SecureString"
+  value       = random_password.origin_secret.result
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-cf-origin-secret"
+  }
+}

--- a/infra/cloudfront/outputs.tf
+++ b/infra/cloudfront/outputs.tf
@@ -1,0 +1,39 @@
+output "distribution_id" {
+  description = "CloudFront distribution ID. Used by the invalidation script on every deploy."
+  value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "distribution_domain_name" {
+  description = "CloudFront-assigned domain name (e.g. d1234abcd.cloudfront.net)."
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "distribution_arn" {
+  description = "ARN of the CloudFront distribution."
+  value       = aws_cloudfront_distribution.frontend.arn
+}
+
+output "distribution_hosted_zone_id" {
+  description = "Route53 hosted zone ID for the CloudFront distribution. Use this when creating an ALIAS record in Route53."
+  value       = aws_cloudfront_distribution.frontend.hosted_zone_id
+}
+
+output "static_assets_cache_policy_id" {
+  description = "ID of the static-assets cache policy (1-year TTL + immutable)."
+  value       = aws_cloudfront_cache_policy.static_assets.id
+}
+
+output "html_pages_cache_policy_id" {
+  description = "ID of the html-pages cache policy (5-minute TTL + stale-while-revalidate)."
+  value       = aws_cloudfront_cache_policy.html_pages.id
+}
+
+output "api_bypass_cache_policy_id" {
+  description = "ID of the api-bypass cache policy (no caching)."
+  value       = aws_cloudfront_cache_policy.api_bypass.id
+}
+
+output "origin_secret_ssm_path" {
+  description = "SSM Parameter Store path where the CloudFront origin secret is stored."
+  value       = aws_ssm_parameter.origin_secret.name
+}

--- a/infra/cloudfront/variables.tf
+++ b/infra/cloudfront/variables.tf
@@ -1,0 +1,62 @@
+variable "aws_region" {
+  description = "AWS region to deploy CloudFront resources (ACM certificate must be in us-east-1 regardless)."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. production, staging)."
+  type        = string
+  default     = "production"
+}
+
+variable "project_name" {
+  description = "Short project name used in resource names and tags."
+  type        = string
+  default     = "aura-vault"
+}
+
+variable "origin_domain_name" {
+  description = "Domain name of the origin (e.g. ALB or S3 static website endpoint serving the frontend)."
+  type        = string
+}
+
+variable "origin_id" {
+  description = "Unique identifier for the CloudFront origin."
+  type        = string
+  default     = "aura-vault-frontend-origin"
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of the ACM certificate in us-east-1 for the CloudFront distribution. Must cover the aliases below."
+  type        = string
+}
+
+variable "domain_aliases" {
+  description = "List of custom domain aliases for the CloudFront distribution (e.g. [\"app.auravault.io\"])."
+  type        = list(string)
+  default     = []
+}
+
+variable "price_class" {
+  description = "CloudFront price class. PriceClass_100 = US/EU, PriceClass_200 adds more regions, PriceClass_All = global."
+  type        = string
+  default     = "PriceClass_100"
+
+  validation {
+    condition     = contains(["PriceClass_100", "PriceClass_200", "PriceClass_All"], var.price_class)
+    error_message = "price_class must be one of: PriceClass_100, PriceClass_200, PriceClass_All."
+  }
+}
+
+variable "web_acl_id" {
+  description = "Optional AWS WAF Web ACL ARN to associate with the distribution."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
- main.tf: CloudFront distribution with per-content-type cache behaviors
  - /api/* → bypass (TTL 0, all headers/cookies forwarded)
  - *.js, *.css, fonts, images, _next/static/* → 1 year + immutable
  - default (HTML) → 5 min + stale-while-revalidate=60
- cache-policies.tf: three named cache policies + response headers policies
  - static-assets: max-age=31536000, immutable
  - html-pages: max-age=300, stale-while-revalidate=60
  - api-bypass: TTL 0, no caching
- variables.tf: inputs for origin, ACM cert, aliases, price class
- outputs.tf: distribution_id, domain_name, hosted_zone_id
- invalidation.sh: runs aws cloudfront create-invalidation /* on deploy
- HTTPS enforced: redirect-to-https + TLSv1.2_2021 minimum
- Security headers injected via CloudFront Function (HSTS, X-Frame-Options)
- README.md: deployment, variable reference, CI integration guide

Closes #507