### PR TITLE
feat(infra): configure multi-region failover for high availability (#…

### DIFF
--- a/.github/workflows/dr-failover-test.yml
+++ b/.github/workflows/dr-failover-test.yml
@@ -1,0 +1,273 @@
+name: DR Failover Test
+
+on:
+  schedule:
+    # Quarterly — 1st of January, April, July, October at 06:00 UTC
+    - cron: '0 6 1 1,4,7,10 *'
+  workflow_dispatch:
+    inputs:
+      promote:
+        description: 'Promote DR replica to standalone (only for actual DR drill, not health check)'
+        type: boolean
+        default: false
+      environment:
+        description: 'Environment to test'
+        type: choice
+        options: [staging, production]
+        default: staging
+
+concurrency:
+  group: dr-failover-test
+  cancel-in-progress: false
+
+jobs:
+  dr-test:
+    name: DR Failover Health Check & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (primary region)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.5.0'
+
+      - name: Read DR config from SSM
+        id: dr_config
+        run: |
+          CONFIG=$(aws ssm get-parameter \
+            --name "/aura-vault/prod/dr/config" \
+            --query "Parameter.Value" \
+            --output text 2>/dev/null || echo '{}')
+          echo "config=${CONFIG}" >> "$GITHUB_OUTPUT"
+          DR_REPLICA=$(echo "${CONFIG}" | jq -r '.dr_replica_id // "aura-vault-db-dr-prod"')
+          echo "dr_replica_id=${DR_REPLICA}" >> "$GITHUB_OUTPUT"
+          PRIMARY_DB=$(echo "${CONFIG}" | jq -r '.primary_db_id // "aura-vault-db-prod"')
+          echo "primary_db_id=${PRIMARY_DB}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify DR replica status
+        id: replica_status
+        run: |
+          DR_ID="${{ steps.dr_config.outputs.dr_replica_id }}"
+          echo "Checking DR replica: ${DR_ID}"
+
+          STATUS=$(aws rds describe-db-instances \
+            --db-instance-identifier "${DR_ID}" \
+            --region eu-west-1 \
+            --query "DBInstances[0].DBInstanceStatus" \
+            --output text 2>/dev/null || echo "not-found")
+
+          echo "dr_replica_status=${STATUS}" >> "$GITHUB_OUTPUT"
+          echo "DR replica status: ${STATUS}"
+
+          if [ "${STATUS}" == "available" ]; then
+            echo "replica_healthy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "replica_healthy=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ DR replica is not in 'available' state: ${STATUS}"
+          fi
+
+      - name: Measure replication lag (RPO assessment)
+        id: replication_lag
+        run: |
+          DR_ID="${{ steps.dr_config.outputs.dr_replica_id }}"
+          END_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          START_TIME=$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -u -v-5M +%Y-%m-%dT%H:%M:%SZ)
+
+          LAG_JSON=$(aws cloudwatch get-metric-statistics \
+            --namespace "AWS/RDS" \
+            --metric-name "ReplicaLag" \
+            --dimensions "Name=DBInstanceIdentifier,Value=${DR_ID}" \
+            --start-time "${START_TIME}" \
+            --end-time "${END_TIME}" \
+            --period 300 \
+            --statistics Average \
+            --region eu-west-1 \
+            --output json 2>/dev/null || echo '{"Datapoints":[]}')
+
+          LAG=$(echo "${LAG_JSON}" | jq -r '.Datapoints | sort_by(.Timestamp) | last | .Average // -1')
+          echo "replica_lag_seconds=${LAG}" >> "$GITHUB_OUTPUT"
+
+          if [ "${LAG}" == "-1" ] || [ "${LAG}" == "null" ]; then
+            echo "lag_status=no_data" >> "$GITHUB_OUTPUT"
+            echo "⚠️ No replication lag data available (replica may be unavailable)"
+          elif (( $(echo "${LAG} <= 300" | bc -l 2>/dev/null || echo 0) )); then
+            echo "lag_status=within_rpo" >> "$GITHUB_OUTPUT"
+            echo "✅ Replication lag ${LAG}s is within 5-minute RPO target"
+          else
+            echo "lag_status=exceeds_rpo" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Replication lag ${LAG}s EXCEEDS 5-minute RPO target (300s)"
+          fi
+
+      - name: Check Route 53 health check status
+        id: health_checks
+        run: |
+          # Get health check IDs for primary
+          PRIMARY_HC=$(aws route53 list-health-checks \
+            --query "HealthChecks[?HealthCheckConfig.FullyQualifiedDomainName!=null] | [0].Id" \
+            --output text 2>/dev/null || echo "")
+
+          if [ -n "${PRIMARY_HC}" ] && [ "${PRIMARY_HC}" != "None" ]; then
+            HC_STATUS=$(aws route53 get-health-check-status \
+              --health-check-id "${PRIMARY_HC}" \
+              --query "HealthCheckObservations[*].StatusReport.Status" \
+              --output text 2>/dev/null || echo "unknown")
+            echo "primary_hc_status=${HC_STATUS}" >> "$GITHUB_OUTPUT"
+            echo "Primary health check status: ${HC_STATUS}"
+          else
+            echo "primary_hc_status=not_configured" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Promote DR replica to standalone (actual DR drill only)
+        id: promote
+        if: github.event.inputs.promote == 'true'
+        run: |
+          DR_ID="${{ steps.dr_config.outputs.dr_replica_id }}"
+          echo "⚠️ PROMOTING DR REPLICA TO STANDALONE: ${DR_ID}"
+          echo "This will break replication. Manual intervention required to re-establish."
+
+          PROMOTE_START=$(date +%s)
+
+          aws rds promote-read-replica \
+            --db-instance-identifier "${DR_ID}" \
+            --region eu-west-1
+
+          echo "Waiting for promotion to complete (target RTO: 30 minutes)..."
+          aws rds wait db-instance-available \
+            --db-instance-identifier "${DR_ID}" \
+            --region eu-west-1
+
+          PROMOTE_END=$(date +%s)
+          RTO_SECONDS=$(( PROMOTE_END - PROMOTE_START ))
+          RTO_MINUTES=$(echo "scale=1; ${RTO_SECONDS}/60" | bc)
+
+          echo "rto_minutes=${RTO_MINUTES}" >> "$GITHUB_OUTPUT"
+          echo "✅ Promotion completed in ${RTO_MINUTES} minutes"
+
+          if (( $(echo "${RTO_MINUTES} <= 30" | bc -l) )); then
+            echo "rto_status=within_target" >> "$GITHUB_OUTPUT"
+          else
+            echo "rto_status=exceeds_target" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build test results
+        id: results
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          REPLICA_STATUS="${{ steps.replica_status.outputs.dr_replica_status }}"
+          REPLICA_HEALTHY="${{ steps.replica_status.outputs.replica_healthy }}"
+          LAG="${{ steps.replication_lag.outputs.replica_lag_seconds }}"
+          LAG_STATUS="${{ steps.replication_lag.outputs.lag_status }}"
+          PROMOTED="${{ github.event.inputs.promote }}"
+          RTO="${{ steps.promote.outputs.rto_minutes }}"
+
+          cat > dr_test_results.json <<EOF
+          {
+            "timestamp": "${TIMESTAMP}",
+            "dr_replica_id": "${{ steps.dr_config.outputs.dr_replica_id }}",
+            "primary_db_id": "${{ steps.dr_config.outputs.primary_db_id }}",
+            "replica_status": "${REPLICA_STATUS}",
+            "replica_healthy": ${REPLICA_HEALTHY:-false},
+            "replication_lag_seconds": ${LAG:--1},
+            "lag_status": "${LAG_STATUS}",
+            "rpo_target_seconds": 300,
+            "rpo_met": $([ "${LAG_STATUS}" == "within_rpo" ] && echo true || echo false),
+            "promotion_performed": ${PROMOTED:-false},
+            "rto_minutes": ${RTO:-null},
+            "rto_target_minutes": 30,
+            "rto_met": $([ "${{ steps.promote.outputs.rto_status }}" == "within_target" ] && echo true || echo false),
+            "workflow_run": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }
+          EOF
+
+          cat dr_test_results.json
+
+      - name: Upload DR test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: dr-test-results-${{ github.run_id }}
+          retention-days: 90
+          path: dr_test_results.json
+
+      - name: Send SNS notification with results
+        run: |
+          RESULTS=$(cat dr_test_results.json | tr -d '\n' | head -c 4000)
+          REPLICA_HEALTHY="${{ steps.replica_status.outputs.replica_healthy }}"
+          LAG_STATUS="${{ steps.replication_lag.outputs.lag_status }}"
+
+          if [ "${REPLICA_HEALTHY}" == "true" ] && [ "${LAG_STATUS}" == "within_rpo" ]; then
+            STATUS="PASS"
+          else
+            STATUS="DEGRADED"
+          fi
+
+          # Publish to failover alerts SNS topic if configured
+          TOPIC_ARN=$(aws sns list-topics \
+            --query "Topics[?contains(TopicArn, 'failover-alerts')].TopicArn | [0]" \
+            --output text 2>/dev/null || echo "")
+
+          if [ -n "${TOPIC_ARN}" ] && [ "${TOPIC_ARN}" != "None" ]; then
+            aws sns publish \
+              --topic-arn "${TOPIC_ARN}" \
+              --subject "[${STATUS}] Quarterly DR Failover Test — $(date +%Y-%m-%d)" \
+              --message "${RESULTS}" \
+              2>/dev/null || echo "SNS publish failed (non-fatal)"
+          fi
+
+      - name: Post summary to GitHub Step Summary
+        if: always()
+        run: |
+          REPLICA_HEALTHY="${{ steps.replica_status.outputs.replica_healthy }}"
+          LAG="${{ steps.replication_lag.outputs.replica_lag_seconds }}"
+          LAG_STATUS="${{ steps.replication_lag.outputs.lag_status }}"
+
+          echo "## 🌍 DR Failover Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Date:** $(date -u)" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Primary Region:** us-east-1 | **DR Region:** eu-west-1" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Check | Status | Target |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${REPLICA_HEALTHY}" == "true" ]; then
+            echo "| DR Replica Status | ✅ Available | Available |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| DR Replica Status | ❌ ${{ steps.replica_status.outputs.dr_replica_status }} | Available |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          case "${LAG_STATUS}" in
+            within_rpo)  echo "| Replication Lag | ✅ ${LAG}s | ≤ 300s (5 min) |" >> "$GITHUB_STEP_SUMMARY" ;;
+            exceeds_rpo) echo "| Replication Lag | ⚠️ ${LAG}s — EXCEEDS RPO | ≤ 300s (5 min) |" >> "$GITHUB_STEP_SUMMARY" ;;
+            *)           echo "| Replication Lag | ❓ No data | ≤ 300s (5 min) |" >> "$GITHUB_STEP_SUMMARY" ;;
+          esac
+
+          if [ "${{ github.event.inputs.promote }}" == "true" ]; then
+            RTO="${{ steps.promote.outputs.rto_minutes }}"
+            RTO_STATUS="${{ steps.promote.outputs.rto_status }}"
+            if [ "${RTO_STATUS}" == "within_target" ]; then
+              echo "| Failover RTO | ✅ ${RTO} min | ≤ 30 min |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| Failover RTO | ⚠️ ${RTO} min — EXCEEDS TARGET | ≤ 30 min |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "| Failover RTO | ℹ️ Health check only (not tested) | ≤ 30 min |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> **Note:** To execute an actual failover drill, re-run with \`promote: true\` input." >> "$GITHUB_STEP_SUMMARY"
+          echo "> See [DR Runbook](docs/disaster-recovery/runbook.md) for procedures." >> "$GITHUB_STEP_SUMMARY"

--- a/terraform/dr-vpc.tf
+++ b/terraform/dr-vpc.tf
@@ -1,0 +1,123 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #523: DR Region VPC Infrastructure (eu-west-1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── VPC ───────────────────────────────────────────────────────────────────
+
+resource "aws_vpc" "dr" {
+  provider             = aws.dr
+  cidr_block           = var.dr_vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.project_name}-vpc-dr-${var.environment}"
+  }
+}
+
+# ── Public Subnets ────────────────────────────────────────────────────────
+
+resource "aws_subnet" "dr_public" {
+  provider          = aws.dr
+  count             = 2
+  vpc_id            = aws_vpc.dr.id
+  cidr_block        = cidrsubnet(var.dr_vpc_cidr, 8, count.index)
+  availability_zone = var.dr_availability_zones[count.index]
+
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-dr-public-${count.index + 1}-${var.environment}"
+    Tier = "public"
+  }
+}
+
+# ── Private Subnets ───────────────────────────────────────────────────────
+
+resource "aws_subnet" "dr_private" {
+  provider          = aws.dr
+  count             = 2
+  vpc_id            = aws_vpc.dr.id
+  cidr_block        = cidrsubnet(var.dr_vpc_cidr, 8, count.index + 10)
+  availability_zone = var.dr_availability_zones[count.index]
+
+  tags = {
+    Name = "${var.project_name}-dr-private-${count.index + 1}-${var.environment}"
+    Tier = "private"
+  }
+}
+
+# ── Internet Gateway ──────────────────────────────────────────────────────
+
+resource "aws_internet_gateway" "dr" {
+  provider = aws.dr
+  vpc_id   = aws_vpc.dr.id
+
+  tags = {
+    Name = "${var.project_name}-igw-dr-${var.environment}"
+  }
+}
+
+# ── Public Route Table ────────────────────────────────────────────────────
+
+resource "aws_route_table" "dr_public" {
+  provider = aws.dr
+  vpc_id   = aws_vpc.dr.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.dr.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-dr-rt-public-${var.environment}"
+  }
+}
+
+resource "aws_route_table_association" "dr_public" {
+  provider       = aws.dr
+  count          = 2
+  subnet_id      = aws_subnet.dr_public[count.index].id
+  route_table_id = aws_route_table.dr_public.id
+}
+
+# ── DB Subnet Group (DR) ──────────────────────────────────────────────────
+
+resource "aws_db_subnet_group" "dr" {
+  provider   = aws.dr
+  name       = "${var.project_name}-db-subnet-group-dr-${var.environment}"
+  subnet_ids = aws_subnet.dr_private[*].id
+
+  tags = {
+    Name = "${var.project_name}-db-subnet-group-dr-${var.environment}"
+  }
+}
+
+# ── Security Group: DR RDS ────────────────────────────────────────────────
+
+resource "aws_security_group" "dr_rds" {
+  provider    = aws.dr
+  name        = "${var.project_name}-sg-dr-rds-${var.environment}"
+  description = "Security group for DR RDS read replica"
+  vpc_id      = aws_vpc.dr.id
+
+  ingress {
+    description = "PostgreSQL from DR VPC"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [var.dr_vpc_cidr]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-sg-dr-rds-${var.environment}"
+  }
+}

--- a/terraform/multi-region.tf
+++ b/terraform/multi-region.tf
@@ -1,0 +1,295 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #523: Multi-Region Failover — Primary: us-east-1 / DR: eu-west-1
+# RTO target: < 30 minutes | RPO target: < 5 minutes
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── DR Region Provider ────────────────────────────────────────────────────
+
+provider "aws" {
+  alias  = "dr"
+  region = var.dr_region
+
+  default_tags {
+    tags = {
+      Project     = "aura-vault-protocol"
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Role        = "disaster-recovery"
+    }
+  }
+}
+
+# ── RDS: Cross-Region Automated Backup Replication ────────────────────────
+
+resource "aws_db_instance_automated_backups_replication" "to_dr" {
+  source_db_instance_arn = aws_db_instance.main.arn
+  retention_period       = 7
+
+  provider = aws.dr
+}
+
+# ── RDS: Cross-Region Read Replica (DR) ──────────────────────────────────
+
+resource "aws_db_instance" "dr_replica" {
+  provider = aws.dr
+
+  identifier = "${var.project_name}-db-dr-${var.environment}"
+
+  # Cross-region replica: point at the primary instance ARN
+  replicate_source_db = aws_db_instance.main.arn
+
+  instance_class = var.db_instance_class
+  storage_type   = "gp3"
+  storage_encrypted = true
+
+  # Replica-specific settings
+  multi_az               = false
+  publicly_accessible    = false
+  auto_minor_version_upgrade = true
+
+  backup_retention_period = 7
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "Mon:04:00-Mon:05:00"
+
+  performance_insights_enabled = true
+  monitoring_interval          = 60
+  monitoring_role_arn          = aws_iam_role.rds_monitoring_dr.arn
+
+  deletion_protection = var.environment == "prod"
+  skip_final_snapshot = var.environment != "prod"
+  final_snapshot_identifier = var.environment == "prod" ? "${var.project_name}-db-dr-final-${var.environment}" : null
+
+  db_subnet_group_name   = aws_db_subnet_group.dr.name
+  vpc_security_group_ids = [aws_security_group.dr_rds.id]
+
+  tags = {
+    Name = "${var.project_name}-db-dr-${var.environment}"
+    Role = "cross-region-read-replica"
+  }
+
+  depends_on = [
+    aws_db_instance_automated_backups_replication.to_dr,
+    aws_iam_role_policy_attachment.rds_monitoring_dr,
+  ]
+}
+
+# ── IAM: RDS Enhanced Monitoring Role (DR region) ─────────────────────────
+
+resource "aws_iam_role" "rds_monitoring_dr" {
+  provider = aws.dr
+  name     = "${var.project_name}-rds-monitoring-dr-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "monitoring.rds.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.project_name}-rds-monitoring-dr-${var.environment}"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "rds_monitoring_dr" {
+  provider   = aws.dr
+  role       = aws_iam_role.rds_monitoring_dr.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+# ── Route 53 Health Check: Primary ALB ───────────────────────────────────
+
+resource "aws_route53_health_check" "primary_alb" {
+  fqdn              = aws_lb.main.dns_name
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/api/health"
+  failure_threshold = 3
+  request_interval  = 30
+
+  tags = {
+    Name = "${var.project_name}-primary-alb-health-${var.environment}"
+  }
+}
+
+# ── Route 53 Health Check: DR Endpoint ────────────────────────────────────
+
+resource "aws_route53_health_check" "dr_endpoint" {
+  count = var.dr_alb_dns_name != "" ? 1 : 0
+
+  fqdn              = var.dr_alb_dns_name
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/api/health"
+  failure_threshold = 3
+  request_interval  = 30
+
+  tags = {
+    Name = "${var.project_name}-dr-endpoint-health-${var.environment}"
+  }
+}
+
+# ── Route 53 Failover DNS Records ─────────────────────────────────────────
+
+resource "aws_route53_record" "primary_failover" {
+  count   = var.domain_name != "" ? 1 : 0
+  zone_id = aws_route53_zone.main[0].id
+  name    = "api.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 60
+  records = [aws_lb.main.dns_name]
+
+  set_identifier = "primary"
+
+  failover_routing_policy {
+    type = "PRIMARY"
+  }
+
+  health_check_id = aws_route53_health_check.primary_alb.id
+}
+
+resource "aws_route53_record" "secondary_failover" {
+  count   = var.domain_name != "" && var.dr_alb_dns_name != "" ? 1 : 0
+  zone_id = aws_route53_zone.main[0].id
+  name    = "api.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 60
+  records = [var.dr_alb_dns_name]
+
+  set_identifier = "secondary"
+
+  failover_routing_policy {
+    type = "SECONDARY"
+  }
+
+  health_check_id = aws_route53_health_check.dr_endpoint[0].id
+}
+
+# ── SNS: Failover Alerts ──────────────────────────────────────────────────
+
+resource "aws_sns_topic" "failover_alerts" {
+  name = "${var.project_name}-failover-alerts-${var.environment}"
+
+  tags = {
+    Name = "${var.project_name}-failover-alerts-${var.environment}"
+  }
+}
+
+resource "aws_sns_topic_subscription" "failover_email" {
+  count     = var.alert_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.failover_alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# ── CloudWatch: Replication Lag Alarm (DR region) ─────────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "rds_replica_lag" {
+  provider = aws.dr
+
+  alarm_name          = "${var.project_name}-replica-lag-${var.environment}"
+  alarm_description   = "RDS replica lag exceeds RPO target of 5 minutes (300 seconds)"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "ReplicaLag"
+  namespace           = "AWS/RDS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 300 # 5 minutes — RPO target
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.dr_replica.identifier
+  }
+
+  # Cross-region SNS: publish to primary region topic
+  alarm_actions = [aws_sns_topic.failover_alerts.arn]
+  ok_actions    = [aws_sns_topic.failover_alerts.arn]
+
+  tags = {
+    Name = "${var.project_name}-replica-lag-${var.environment}"
+  }
+}
+
+# ── CloudWatch: Primary ALB Healthy Host Count Alarm ─────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "primary_alb_health" {
+  alarm_name          = "${var.project_name}-alb-healthy-hosts-${var.environment}"
+  alarm_description   = "Primary ALB has no healthy targets — consider DR failover"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 1
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    LoadBalancer = aws_lb.main.arn_suffix
+    TargetGroup  = aws_lb_target_group.backend.arn_suffix
+  }
+
+  alarm_actions = [aws_sns_topic.failover_alerts.arn]
+  ok_actions    = [aws_sns_topic.failover_alerts.arn]
+
+  tags = {
+    Name = "${var.project_name}-alb-healthy-hosts-${var.environment}"
+  }
+}
+
+# ── SSM Parameter: DR Configuration (for runbooks/automation) ─────────────
+
+resource "aws_ssm_parameter" "dr_config" {
+  name        = "/${var.project_name}/${var.environment}/dr/config"
+  description = "Disaster recovery configuration for runbooks and automation"
+  type        = "String"
+
+  value = jsonencode({
+    primary_region   = var.aws_region
+    dr_region        = var.dr_region
+    rto_minutes      = 30
+    rpo_minutes      = 5
+    primary_db_id    = aws_db_instance.main.identifier
+    dr_replica_id    = aws_db_instance.dr_replica.identifier
+    failover_dns     = var.domain_name != "" ? "api.${var.domain_name}" : ""
+    last_updated     = timestamp()
+  })
+
+  lifecycle {
+    ignore_changes = [value] # Prevent perpetual diff from timestamp()
+  }
+
+  tags = {
+    Name = "${var.project_name}-dr-config-${var.environment}"
+  }
+}
+
+# ── EventBridge: Quarterly DR Test Reminder ───────────────────────────────
+
+resource "aws_cloudwatch_event_rule" "dr_test_reminder" {
+  name                = "${var.project_name}-dr-test-reminder-${var.environment}"
+  description         = "Quarterly reminder to execute the DR failover test drill"
+  schedule_expression = var.failover_test_schedule
+
+  tags = {
+    Name = "${var.project_name}-dr-test-reminder-${var.environment}"
+  }
+}
+
+resource "aws_cloudwatch_event_target" "dr_test_reminder_sns" {
+  rule      = aws_cloudwatch_event_rule.dr_test_reminder.name
+  target_id = "dr-test-reminder-sns"
+  arn       = aws_sns_topic.failover_alerts.arn
+
+  input = jsonencode({
+    message = "ACTION REQUIRED: Quarterly DR failover test is due. Please execute the dr-failover-test workflow."
+    wiki    = "See docs/disaster-recovery/runbook.md"
+  })
+}


### PR DESCRIPTION
…523)

Primary region: us-east-1 | DR region: eu-west-1
RTO target: < 30 min | RPO target: < 5 min

- Add multi-region.tf:
  * Provider alias 'aws.dr' for eu-west-1
  * aws_db_instance_automated_backups_replication (cross-region backup replication)
  * aws_db_instance.dr_replica: cross-region read replica in eu-west-1
  * Route 53 health checks for primary ALB and DR endpoint
  * Route 53 failover DNS records (PRIMARY/SECONDARY) for api.<domain>
  * CloudWatch alarm on ReplicaLag > 300s (RPO threshold) in DR region
  * CloudWatch alarm on primary ALB HealthyHostCount < 1
  * SNS topic + email subscription for failover alerts
  * SSM parameter storing DR config (RTO, RPO, replica IDs) for runbooks
  * EventBridge quarterly DR test reminder
- Add dr-vpc.tf:
  * Full VPC for DR region: public + private subnets across 2 AZs
  * Internet gateway and public route table
  * DB subnet group and RDS security group for the replica
- Add dr-failover-test.yml (GitHub Actions):
  * Quarterly schedule: 1st of Jan, Apr, Jul, Oct at 06:00 UTC
  * Checks DR replica status (available/unavailable)
  * Measures replication lag and assesses RPO compliance
  * Checks Route 53 health check status
  * Optional replica promotion (promote: true input — actual DR drill only)
  * Measures RTO when promotion is performed
  * Publishes results to SNS + GitHub Step Summary
  * 90-day artifact retention for audit trail
- New variables: dr_region, dr_vpc_cidr, dr_availability_zones, dr_alb_dns_name, failover_test_schedule
- New outputs: dr_replica_endpoint, failover_alerts_topic_arn, primary_health_check_id

closes #523 