### PR TITLE
feat(ci): implement infrastructure drift detection with Terraform pla…

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -1,0 +1,252 @@
+name: Infrastructure Drift Detection
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      auto_remediate:
+        description: 'Auto-remediate safe drift (tag changes only)'
+        type: boolean
+        default: true
+
+concurrency:
+  group: terraform-drift
+  cancel-in-progress: false
+
+env:
+  TF_WORKING_DIR: terraform
+  TF_VERSION: '1.5.0'
+
+jobs:
+  drift-check:
+    name: Terraform Drift Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform init -input=false
+
+      - name: Terraform Plan (drift detection)
+        id: plan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        continue-on-error: true
+        run: |
+          set +e
+          terraform plan \
+            -detailed-exitcode \
+            -input=false \
+            -out=tfplan.binary \
+            -var="db_username=${{ secrets.TF_VAR_DB_USERNAME }}" \
+            -var="ssh_public_key=${{ secrets.TF_VAR_SSH_PUBLIC_KEY }}" \
+            2>&1 | tee plan_output.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+          echo "Terraform plan exit code: ${EXIT_CODE}"
+          # Exit codes: 0 = no changes, 1 = error, 2 = changes detected
+          exit 0
+
+      - name: Convert plan to JSON
+        if: steps.plan.outputs.exit_code != '1'
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform show -json tfplan.binary > tfplan.json
+
+      - name: Generate drift report
+        id: drift_report
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          if [ "${{ steps.plan.outputs.exit_code }}" == "2" ]; then
+            echo "=== DRIFT DETECTED ===" >> drift_report.txt
+            echo "Timestamp: $(date -u)" >> drift_report.txt
+            echo "Repository: ${{ github.repository }}" >> drift_report.txt
+            echo "Workflow Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> drift_report.txt
+            echo "" >> drift_report.txt
+            echo "=== CHANGED RESOURCES ===" >> drift_report.txt
+            if command -v jq &>/dev/null && [ -f tfplan.json ]; then
+              jq -r '
+                .resource_changes[]
+                | select(.change.actions | map(. != "no-op") | any)
+                | "Resource: " + .address
+                  + "\nActions: " + (.change.actions | join(", "))
+                  + "\nModule: " + (.module_address // "root")
+                  + "\n---"
+              ' tfplan.json >> drift_report.txt 2>/dev/null || echo "Could not parse JSON plan" >> drift_report.txt
+
+              echo "" >> drift_report.txt
+              echo "=== ATTRIBUTE CHANGES ===" >> drift_report.txt
+              jq -r '
+                .resource_changes[]
+                | select(.change.actions | map(. != "no-op") | any)
+                | .address as $addr
+                | (.change.before // {} | to_entries) as $before
+                | (.change.after // {} | to_entries) as $after
+                | ($after - $before | map(select(.key != "tags_all")))
+                | select(length > 0)
+                | "Resource: " + $addr + "\nChanged attributes:"
+                  + (map("\n  - " + .key + ": " + (.value | tostring)) | join(""))
+                  + "\n---"
+              ' tfplan.json >> drift_report.txt 2>/dev/null || true
+            else
+              grep -E '^\s+[~+\-]' plan_output.txt >> drift_report.txt 2>/dev/null || true
+            fi
+            echo "drift_detected=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.plan.outputs.exit_code }}" == "0" ]; then
+            echo "=== NO DRIFT DETECTED ===" > drift_report.txt
+            echo "Timestamp: $(date -u)" >> drift_report.txt
+            echo "Infrastructure matches Terraform state." >> drift_report.txt
+            echo "drift_detected=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "=== PLAN FAILED ===" > drift_report.txt
+            echo "Terraform plan returned an error. See plan_output.txt for details." >> drift_report.txt
+            echo "drift_detected=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: drift-report-${{ github.run_id }}
+          retention-days: 30
+          path: |
+            ${{ env.TF_WORKING_DIR }}/plan_output.txt
+            ${{ env.TF_WORKING_DIR }}/drift_report.txt
+            ${{ env.TF_WORKING_DIR }}/tfplan.json
+
+      - name: Send Slack alert (drift detected)
+        if: steps.plan.outputs.exit_code == '2' && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          PLAN_SUMMARY=$(head -c 2000 terraform/plan_output.txt | sed 's/"/\\"/g' | tr '\n' ' ')
+          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"text\": \":warning: *Infrastructure Drift Detected*\",
+              \"attachments\": [
+                {
+                  \"color\": \"warning\",
+                  \"fields\": [
+                    {\"title\": \"Repository\", \"value\": \"${{ github.repository }}\", \"short\": true},
+                    {\"title\": \"Timestamp\", \"value\": \"$(date -u)\", \"short\": true},
+                    {\"title\": \"Workflow Run\", \"value\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\", \"short\": false},
+                    {\"title\": \"Plan Summary\", \"value\": \"\`\`\`${PLAN_SUMMARY}\`\`\`\", \"short\": false}
+                  ]
+                }
+              ]
+            }" || echo "Slack notification failed (non-fatal)"
+
+      - name: Auto-remediate safe drift (tag changes only)
+        id: auto_remediate
+        if: steps.plan.outputs.exit_code == '2'
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          # Detect whether ALL changes are limited to tag modifications
+          NON_TAG_CHANGES=$(grep -E '^\s+[~+\-]' plan_output.txt \
+            | grep -v '"tags"' \
+            | grep -v '"tags_all"' \
+            | grep -c '.' || true)
+
+          if [ "$NON_TAG_CHANGES" -eq 0 ] && \
+             [ "${{ github.event.inputs.auto_remediate }}" != "false" ]; then
+            echo "All drift is tag-only — applying auto-remediation..."
+
+            # Extract changed resource addresses from the JSON plan
+            if [ -f tfplan.json ]; then
+              RESOURCES=$(jq -r \
+                '.resource_changes[] | select(.change.actions | map(. != "no-op") | any) | .address' \
+                tfplan.json 2>/dev/null | head -20)
+
+              if [ -n "$RESOURCES" ]; then
+                TARGET_ARGS=$(echo "$RESOURCES" | sed 's/^/-target=/' | tr '\n' ' ')
+                terraform apply -auto-approve $TARGET_ARGS \
+                  -var="db_username=${{ secrets.TF_VAR_DB_USERNAME }}" \
+                  -var="ssh_public_key=${{ secrets.TF_VAR_SSH_PUBLIC_KEY }}" \
+                  2>&1 | tee remediation_output.txt
+                echo "remediation_status=auto_remediated" >> "$GITHUB_OUTPUT"
+                echo "✅ Auto-remediation applied (tag changes only)." >> "$GITHUB_STEP_SUMMARY"
+              fi
+            fi
+          else
+            echo "Non-tag drift detected — manual review required."
+            echo "remediation_status=manual_review_required" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub issue (manual review required)
+        if: >
+          steps.plan.outputs.exit_code == '2' &&
+          steps.auto_remediate.outputs.remediation_status == 'manual_review_required'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPORT=$(cat terraform/drift_report.txt | head -c 5000)
+          gh issue create \
+            --title "[Drift] Infrastructure drift detected $(date +%Y-%m-%d)" \
+            --body "## Infrastructure Drift Detected
+
+          **Date:** $(date -u)
+          **Workflow:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ## Drift Report
+          \`\`\`
+          ${REPORT}
+          \`\`\`
+
+          ## Action Required
+          Manual review is required. The drift includes changes beyond tag modifications.
+          Please review the plan output and apply or revert as appropriate.
+
+          /cc @${{ github.repository_owner }}" \
+            --label "infrastructure" \
+            --repo "${{ github.repository }}" || echo "Issue creation failed (non-fatal)"
+
+      - name: Fail on Terraform plan error
+        if: steps.plan.outputs.exit_code == '1'
+        run: |
+          echo "❌ Terraform plan returned an error. Check plan_output.txt artifact."
+          exit 1
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo "## 🔍 Infrastructure Drift Detection Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Run time** | $(date -u) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Trigger** | ${{ github.event_name }} |" >> "$GITHUB_STEP_SUMMARY"
+
+          case "${{ steps.plan.outputs.exit_code }}" in
+            0) echo "| **Status** | ✅ No drift detected |" >> "$GITHUB_STEP_SUMMARY" ;;
+            2) echo "| **Status** | ⚠️ Drift detected — see artifacts |" >> "$GITHUB_STEP_SUMMARY" ;;
+            1) echo "| **Status** | ❌ Terraform plan error |" >> "$GITHUB_STEP_SUMMARY" ;;
+            *) echo "| **Status** | ❓ Unknown |" >> "$GITHUB_STEP_SUMMARY" ;;
+          esac
+
+          if [ -f terraform/drift_report.txt ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Drift Report" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+            head -c 3000 terraform/drift_report.txt >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/terraform/drift-detection.tf
+++ b/terraform/drift-detection.tf
@@ -1,0 +1,147 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #522: Infrastructure Drift Detection (Terraform)
+#
+# This file supplements the GitHub Actions workflow (.github/workflows/terraform-drift.yml)
+# with AWS-native drift monitoring infrastructure.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── SSM Parameter: Drift Notification Config ─────────────────────────────
+
+resource "aws_ssm_parameter" "drift_notification_config" {
+  name        = "/${var.project_name}/${var.environment}/drift-detection/config"
+  description = "Configuration for infrastructure drift detection and notifications"
+  type        = "String"
+
+  value = jsonencode({
+    slack_webhook_configured = "see-github-secrets:SLACK_WEBHOOK_URL"
+    drift_check_schedule     = "daily-06:00-UTC"
+    auto_remediation_enabled = true
+    safe_drift_types         = ["tag_changes"]
+    manual_review_required   = ["resource_creation", "resource_deletion", "attribute_change"]
+  })
+
+  tags = {
+    Name = "${var.project_name}-drift-config-${var.environment}"
+  }
+}
+
+# ── EventBridge: Daily Drift Detection Reminder ───────────────────────────
+# Supplements the GitHub Actions cron — provides an AWS-native fallback alert
+# if the GHA workflow fails to run.
+
+resource "aws_cloudwatch_event_rule" "drift_detection_schedule" {
+  name                = "${var.project_name}-drift-detection-${var.environment}"
+  description         = "Daily drift detection schedule — triggers SNS if GitHub Actions workflow is unavailable"
+  schedule_expression = "rate(1 day)"
+
+  tags = {
+    Name = "${var.project_name}-drift-detection-${var.environment}"
+  }
+}
+
+# ── SNS Topic: Drift Alerts ───────────────────────────────────────────────
+
+resource "aws_sns_topic" "drift_alerts" {
+  name = "${var.project_name}-drift-alerts-${var.environment}"
+
+  tags = {
+    Name = "${var.project_name}-drift-alerts-${var.environment}"
+  }
+}
+
+resource "aws_sns_topic_subscription" "drift_alerts_email" {
+  count     = var.alert_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.drift_alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+resource "aws_cloudwatch_event_target" "drift_detection_sns" {
+  rule      = aws_cloudwatch_event_rule.drift_detection_schedule.name
+  target_id = "drift-detection-reminder"
+  arn       = aws_sns_topic.drift_alerts.arn
+
+  input = jsonencode({
+    message = "Daily infrastructure drift detection run. Check GitHub Actions: terraform-drift workflow."
+    action  = "verify-github-actions-workflow-ran"
+  })
+}
+
+resource "aws_cloudwatch_event_target" "drift_detection_permission" {
+  rule      = aws_cloudwatch_event_rule.drift_detection_schedule.name
+  target_id = "drift-detection-sns-policy"
+  arn       = aws_sns_topic.drift_alerts.arn
+}
+
+# Allow EventBridge to publish to the SNS topic
+resource "aws_sns_topic_policy" "drift_alerts" {
+  arn = aws_sns_topic.drift_alerts.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridgePublish"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.drift_alerts.arn
+      }
+    ]
+  })
+}
+
+# ── CloudWatch Dashboard: Drift Monitoring ────────────────────────────────
+
+resource "aws_cloudwatch_dashboard" "drift_monitoring" {
+  dashboard_name = "${var.project_name}-drift-monitoring-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 2
+        properties = {
+          markdown = "## Infrastructure Drift Monitoring\nDrift is detected via daily `terraform plan` in GitHub Actions. This dashboard shows related AWS metrics."
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 2
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Config Rule Compliance"
+          metrics = [
+            ["AWS/Config", "ComplianceByConfigRule"]
+          ]
+          period = 86400
+          stat   = "Average"
+          view   = "timeSeries"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 2
+        width  = 12
+        height = 6
+        properties = {
+          title   = "CloudTrail API Events (Infrastructure Changes)"
+          metrics = [
+            ["AWS/CloudTrail", "TotalEvents"]
+          ]
+          period = 3600
+          stat   = "Sum"
+          view   = "timeSeries"
+        }
+      }
+    ]
+  })
+}


### PR DESCRIPTION
…n (#522)

- Add GitHub Actions workflow (terraform-drift.yml):
  * Daily schedule at 06:00 UTC + workflow_dispatch
  * terraform plan -detailed-exitcode to detect drift
  * Converts plan to JSON for structured drift reporting
  * Generates drift_report.txt with resource address, actions, attribute changes
  * Slack alert with plan summary when drift detected
  * Auto-remediation: applies -auto-approve only for tag-only changes (safe drift)
  * Creates GitHub issue for manual review when non-tag drift found
  * Uploads plan artifacts (30-day retention)
  * Job summary with drift status table
- Add drift-detection.tf:
  * SNS topic for drift alerts with email subscription
  * EventBridge rule (daily) as AWS-native supplement to GHA workflow
  * SSM parameter storing notification config
  * CloudWatch dashboard for drift/compliance monitoring
- New outputs: (combined in existing outputs.tf append)

closes #522