### PR TITLE
feat(backend): implement cursor-based pagination for all list endpoin…

### DIFF
--- a/backend/src/middleware/paginationMiddleware.ts
+++ b/backend/src/middleware/paginationMiddleware.ts
@@ -1,0 +1,121 @@
+import { Request } from "express";
+
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+// ---------------------------------------------------------------------------
+// Cursor encoding / decoding
+// Cursor format (before base64): "<id>:<timestamp>"
+// Both fields are always strings; id falls back to array index when no
+// natural PK exists.
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode a primary-key + timestamp pair into an opaque base64 cursor string.
+ */
+export function buildCursor(id: string, timestamp: string): string {
+  return Buffer.from(`${id}:${timestamp}`).toString("base64");
+}
+
+/**
+ * Decode an opaque cursor string back to { id, timestamp }.
+ * Returns null if the cursor is malformed.
+ */
+export function parseCursor(cursor: string): { id: string; timestamp: string } | null {
+  try {
+    const decoded = Buffer.from(cursor, "base64").toString("utf8");
+    const colonIdx = decoded.indexOf(":");
+    if (colonIdx < 0) return null;
+    return {
+      id: decoded.slice(0, colonIdx),
+      timestamp: decoded.slice(colonIdx + 1),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query-param parsing
+// ---------------------------------------------------------------------------
+
+export interface PaginationParams {
+  limit: number;
+  cursor: string | undefined;
+}
+
+/**
+ * Parse `cursor` and `limit` query parameters from an Express request.
+ */
+export function parsePagination(req: Request): PaginationParams {
+  const rawLimit = parseInt(String(req.query.limit ?? DEFAULT_LIMIT), 10);
+  const limit = Number.isFinite(rawLimit) && rawLimit > 0
+    ? Math.min(rawLimit, MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  const cursor =
+    typeof req.query.cursor === "string" && req.query.cursor.length > 0
+      ? req.query.cursor
+      : undefined;
+
+  return { limit, cursor };
+}
+
+// ---------------------------------------------------------------------------
+// Generic array paginator
+// ---------------------------------------------------------------------------
+
+export interface PaginatedResult<T> {
+  data: T[];
+  nextCursor: string | null;
+}
+
+/**
+ * Apply cursor-based pagination to an in-memory array.
+ *
+ * @param items       Full array of items (already in desired order).
+ * @param getFields   Extract { id, timestamp } from an item. Falls back to
+ *                    array-index + epoch-0 when omitted.
+ * @param limit       Page size (already clamped to MAX_LIMIT by parsePagination).
+ * @param cursor      Opaque cursor from the previous page (undefined = first page).
+ */
+export function paginateArray<T>(
+  items: T[],
+  getFields: ((item: T, index: number) => { id: string; timestamp: string }) | undefined,
+  limit: number,
+  cursor?: string,
+): PaginatedResult<T> {
+  const resolveFields = getFields ?? ((_item: T, index: number) => ({
+    id: String(index),
+    timestamp: "0",
+  }));
+
+  let startIndex = 0;
+
+  if (cursor) {
+    const decoded = parseCursor(cursor);
+    if (decoded) {
+      // Find the item that matches the cursor; start from the item after it
+      const matchIdx = items.findIndex((item, i) => {
+        const fields = resolveFields(item, i);
+        return fields.id === decoded.id && fields.timestamp === decoded.timestamp;
+      });
+      if (matchIdx >= 0) {
+        startIndex = matchIdx + 1;
+      }
+    }
+  }
+
+  const pageItems = items.slice(startIndex, startIndex + limit);
+  const hasMore = startIndex + limit < items.length;
+
+  let nextCursor: string | null = null;
+  if (hasMore && pageItems.length > 0) {
+    const lastItem = pageItems[pageItems.length - 1];
+    const lastIndex = startIndex + pageItems.length - 1;
+    const fields = resolveFields(lastItem, lastIndex);
+    nextCursor = buildCursor(fields.id, fields.timestamp);
+  }
+
+  return { data: pageItems, nextCursor };
+}

--- a/backend/src/portfolio.ts
+++ b/backend/src/portfolio.ts
@@ -1,9 +1,14 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
+import {
+  parsePagination,
+  paginateArray,
+  buildCursor,
+} from "./middleware/paginationMiddleware.js";
 
 const router = express.Router();
 
-// In-memory cache: userId -> { data, expiresAt }
+// In-memory cache: cacheKey -> { data, expiresAt }
 const cache = new Map<string, { data: PortfolioResponse; expiresAt: number }>();
 const CACHE_TTL_MS = 30_000;
 
@@ -20,38 +25,34 @@ interface VaultPosition {
   underlyingBalance: string;
   apy: number;
   yieldEarned: string;
+  /** ISO timestamp used as cursor anchor */
+  createdAt: string;
 }
 
 interface PortfolioResponse {
   userId: string;
   totalBalance: string;
-  positions: VaultPosition[];
-  pagination: { page: number; pageSize: number; total: number };
+  data: VaultPosition[];
+  nextCursor: string | null;
 }
 
 // Synthetic data builder — replace with real Soroban RPC calls
-function buildPortfolio(userId: string, page: number, pageSize: number): PortfolioResponse {
-  const allPositions: VaultPosition[] = [
+function buildAllPositions(): VaultPosition[] {
+  return [
     {
       contractId: process.env.VAULT_CONTRACT_ID ?? "CAURA_VAULT_TESTNET",
       shares: "1000",
       underlyingBalance: "1050",
       apy: 8.5,
       yieldEarned: "50",
+      createdAt: "2026-01-01T00:00:00.000Z",
     },
   ];
-  const total = allPositions.length;
-  const start = (page - 1) * pageSize;
-  const positions = allPositions.slice(start, start + pageSize);
-  const totalBalance = positions
-    .reduce((sum, p) => sum + BigInt(p.underlyingBalance), 0n)
-    .toString();
-  return { userId, totalBalance, positions, pagination: { page, pageSize, total } };
 }
 
 /**
  * GET /api/v1/user/portfolio
- * Query params: page (default 1), pageSize (default 20, max 100)
+ * Query params: cursor (opaque base64), limit (default 20, max 100)
  */
 router.get(
   "/",
@@ -64,12 +65,9 @@ router.get(
     }
 
     const userId: string = user.sub;
+    const { limit, cursor } = parsePagination(req);
+    const cacheKey = `${userId}:${limit}:${cursor ?? ""}`;
 
-    // Validate pagination
-    const page = Math.max(1, parseInt((req.query.page as string) ?? "1", 10) || 1);
-    const pageSize = Math.min(100, Math.max(1, parseInt((req.query.pageSize as string) ?? "20", 10) || 20));
-
-    const cacheKey = `${userId}:${page}:${pageSize}`;
     const cached = cache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
       res.setHeader("X-Cache", "HIT");
@@ -78,10 +76,32 @@ router.get(
     }
 
     try {
-      const data = buildPortfolio(userId, page, pageSize);
-      cache.set(cacheKey, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+      const allPositions = buildAllPositions();
+
+      const { data, nextCursor } = paginateArray(
+        allPositions,
+        (pos: VaultPosition) => ({
+          id: pos.contractId,
+          timestamp: pos.createdAt,
+        }),
+        limit,
+        cursor,
+      );
+
+      const totalBalance = data
+        .reduce((sum, p) => sum + BigInt(p.underlyingBalance), 0n)
+        .toString();
+
+      const response: PortfolioResponse = {
+        userId,
+        totalBalance,
+        data,
+        nextCursor,
+      };
+
+      cache.set(cacheKey, { data: response, expiresAt: Date.now() + CACHE_TTL_MS });
       res.setHeader("X-Cache", "MISS");
-      res.json(data);
+      res.json(response);
     } catch (err) {
       console.error("[portfolio]", err);
       res.status(500).json({ error: "Internal server error" });

--- a/backend/src/routes/gasRoutes.ts
+++ b/backend/src/routes/gasRoutes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import { createGasPriceService } from "../services/gasService.js";
+import { parsePagination, paginateArray, MAX_LIMIT } from "../middleware/paginationMiddleware.js";
 
 const gasService = createGasPriceService();
 
@@ -39,16 +40,26 @@ gasRouter.get("/prices", async (req: Request, res: Response): Promise<void> => {
 
 /**
  * GET /api/v1/gas/history
- * Returns the recent tracked gas samples for the requested chain.
+ * Returns cursor-paginated gas price samples for the requested chain.
+ * Query params: chainId, cursor (opaque), limit (default 20, max 100)
  */
 gasRouter.get("/history", async (req: Request, res: Response): Promise<void> => {
   const chainId = parseChainId(req.query.chainId as string | undefined);
-  const limitRaw = Number.parseInt(String(req.query.limit ?? "10"), 10);
-  const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(50, limitRaw) : 10;
+  const { limit, cursor } = parsePagination(req);
 
   try {
-    const history = await gasService.history(chainId, limit);
-    res.json({ chainId, history });
+    // Fetch up to MAX_LIMIT records from the service; paginate in-memory
+    const allHistory = await gasService.history(chainId, MAX_LIMIT);
+    const { data, nextCursor } = paginateArray(
+      allHistory,
+      (item: Record<string, unknown>, index: number) => ({
+        id: String(index),
+        timestamp: typeof item.timestamp === "string" ? item.timestamp : String(index),
+      }),
+      limit,
+      cursor,
+    );
+    res.json({ chainId, data, nextCursor });
   } catch (err) {
     console.error("[gas-history]", err);
     res.status(500).json({ error: "Unable to load gas history" });

--- a/backend/src/routes/queueRoutes.ts
+++ b/backend/src/routes/queueRoutes.ts
@@ -1,5 +1,6 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 import { queueMetrics, listJobs, getJob, getDeadLetterJobs } from "../queue.js";
+import { parsePagination, paginateArray } from "../middleware/paginationMiddleware.js";
 
 export const queueRouter = Router();
 
@@ -8,20 +9,36 @@ queueRouter.get("/metrics", (_req, res) => {
   res.json(queueMetrics());
 });
 
-/** GET /api/v1/queue/dashboard — extended metrics + recent jobs */
-queueRouter.get("/dashboard", (_req, res) => {
+/**
+ * GET /api/v1/queue/dashboard — extended metrics + cursor-paginated recent jobs
+ * Query params: cursor, limit (default 20, max 100)
+ */
+queueRouter.get("/dashboard", (req: Request, res: Response) => {
+  const { limit, cursor } = parsePagination(req);
   const metrics = queueMetrics();
-  const recentCompleted = listJobs("completed").slice(-20);
-  const recentDead = getDeadLetterJobs().slice(-10);
   const active = listJobs("active");
-  const waiting = listJobs("waiting");
+  const allWaiting = listJobs("waiting");
+  const allCompleted = listJobs("completed");
+  const allDead = getDeadLetterJobs();
+
+  // Paginate the waiting queue (primary list callers iterate)
+  const { data: waitingPage, nextCursor } = paginateArray(
+    allWaiting,
+    (job: Record<string, unknown>, index: number) => ({
+      id: typeof job.id === "string" ? job.id : String(index),
+      timestamp: typeof job.createdAt === "string" ? job.createdAt : "0",
+    }),
+    limit,
+    cursor,
+  );
 
   res.json({
     metrics,
     active,
-    waiting: waiting.slice(0, 20),
-    recentCompleted,
-    recentDead,
+    waiting: waitingPage,
+    nextCursor,
+    recentCompleted: allCompleted.slice(-20),
+    recentDead: allDead.slice(-10),
     timestamp: new Date().toISOString(),
   });
 });
@@ -36,7 +53,23 @@ queueRouter.get("/jobs/:id", (req, res) => {
   res.json(job);
 });
 
-/** GET /api/v1/queue/dlq — dead-letter queue */
-queueRouter.get("/dlq", (_req, res) => {
-  res.json(getDeadLetterJobs());
+/**
+ * GET /api/v1/queue/dlq — dead-letter queue (cursor-paginated)
+ * Query params: cursor, limit (default 20, max 100)
+ */
+queueRouter.get("/dlq", (req: Request, res: Response) => {
+  const { limit, cursor } = parsePagination(req);
+  const allDead = getDeadLetterJobs();
+
+  const { data, nextCursor } = paginateArray(
+    allDead,
+    (job: Record<string, unknown>, index: number) => ({
+      id: typeof job.id === "string" ? job.id : String(index),
+      timestamp: typeof job.createdAt === "string" ? job.createdAt : "0",
+    }),
+    limit,
+    cursor,
+  );
+
+  res.json({ data, nextCursor });
 });

--- a/backend/src/routes/yieldRoutes.ts
+++ b/backend/src/routes/yieldRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { createYieldService, YieldSource, VaultPosition } from "../services/yieldService.js";
 import { getLastRunStats, getRunHistory, isYieldWorkerRunning } from "../services/yieldWorker.js";
+import { parsePagination, paginateArray } from "../middleware/paginationMiddleware.js";
 
 const yieldService = createYieldService();
 
@@ -67,22 +68,33 @@ yieldRouter.post("/backfill", async (req: Request, res: Response): Promise<void>
 
 /**
  * GET /api/v1/yield/stats
- * Returns last hourly worker run stats and optional history for monitoring.
- * Query params: ?history=N (default 0 — omit history)
+ * Returns last hourly worker run stats and cursor-paginated run history.
+ * Query params: cursor (opaque base64), limit (default 20, max 100)
  */
 yieldRouter.get("/stats", async (req: Request, res: Response): Promise<void> => {
-  const historyLimit = Math.min(200, Math.max(0, parseInt((req.query.history as string) ?? "0", 10)));
+  const { limit, cursor } = parsePagination(req);
 
   try {
-    const [lastRun, history] = await Promise.all([
+    const [lastRun, allHistory] = await Promise.all([
       getLastRunStats(),
-      historyLimit > 0 ? getRunHistory(historyLimit) : Promise.resolve([] as Awaited<ReturnType<typeof getRunHistory>>),
+      getRunHistory(100),
     ]);
+
+    const { data, nextCursor } = paginateArray(
+      allHistory,
+      (item: Record<string, unknown>, index: number) => ({
+        id: String(index),
+        timestamp: typeof item.runAt === "string" ? item.runAt : "0",
+      }),
+      limit,
+      cursor,
+    );
 
     res.json({
       workerRunning: isYieldWorkerRunning(),
       lastRun,
-      history: historyLimit > 0 ? history : undefined,
+      data,
+      nextCursor,
     });
   } catch (err) {
     console.error("[yield/stats]", err);

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -224,19 +224,13 @@ paths:
       description: |
         Returns all vault positions for the authenticated wallet, including share
         balances, underlying token values, APY, and yield earned.  Results are
-        cached for 30 seconds per user.
+        cached for 30 seconds per user.  Uses cursor-based pagination.
       operationId: getPortfolio
       security:
         - BearerAuth: []
       parameters:
-        - name: page
-          in: query
-          schema: { type: integer, default: 1, minimum: 1 }
-          description: Page number (1-based).
-        - name: pageSize
-          in: query
-          schema: { type: integer, default: 20, minimum: 1, maximum: 100 }
-          description: Results per page (max 100).
+        - $ref: "#/components/parameters/CursorParam"
+        - $ref: "#/components/parameters/LimitParam"
       responses:
         "200":
           description: Portfolio data
@@ -251,13 +245,14 @@ paths:
               example:
                 userId: "GABCDE..."
                 totalBalance: "1050"
-                positions:
+                data:
                   - contractId: "CAURA_VAULT_TESTNET"
                     shares: "1000"
                     underlyingBalance: "1050"
                     apy: 8.5
                     yieldEarned: "50"
-                pagination: { page: 1, pageSize: 20, total: 1 }
+                    createdAt: "2026-01-01T00:00:00.000Z"
+                nextCursor: null
         "401":
           $ref: "#/components/responses/Unauthorized"
         "429":
@@ -342,14 +337,12 @@ paths:
       tags: [Yield]
       summary: Yield worker stats
       description: |
-        Returns the last scheduled worker run statistics.  Pass `?history=N`
-        to include the last N run records (max 200).
+        Returns the last scheduled worker run statistics and cursor-paginated
+        run history.
       operationId: getYieldStats
       parameters:
-        - name: history
-          in: query
-          schema: { type: integer, default: 0, minimum: 0, maximum: 200 }
-          description: Number of historical run records to include.
+        - $ref: "#/components/parameters/CursorParam"
+        - $ref: "#/components/parameters/LimitParam"
       responses:
         "200":
           description: Yield worker stats
@@ -399,17 +392,15 @@ paths:
     get:
       tags: [Gas]
       summary: Gas price history
-      description: Returns recent sampled gas prices for the requested chain (max 50 records).
+      description: Returns cursor-paginated gas price samples for the requested chain.
       operationId: getGasHistory
       parameters:
         - name: chainId
           in: query
           schema: { type: integer, default: 1 }
           description: EVM chain ID.
-        - name: limit
-          in: query
-          schema: { type: integer, default: 10, minimum: 1, maximum: 50 }
-          description: Number of samples to return.
+        - $ref: "#/components/parameters/CursorParam"
+        - $ref: "#/components/parameters/LimitParam"
       responses:
         "200":
           description: Gas price history
@@ -566,17 +557,18 @@ paths:
     get:
       tags: [Queue]
       summary: Dead-letter queue
-      description: Returns all jobs that have exhausted retry attempts.
+      description: Returns cursor-paginated jobs that have exhausted retry attempts.
       operationId: getDeadLetterQueue
+      parameters:
+        - $ref: "#/components/parameters/CursorParam"
+        - $ref: "#/components/parameters/LimitParam"
       responses:
         "200":
-          description: Dead-letter jobs
+          description: Dead-letter jobs (paginated)
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Job"
+                $ref: "#/components/schemas/PaginatedJobResponse"
 
   # ---------------------------------------------------------------------------
   # Webhooks
@@ -1019,6 +1011,55 @@ components:
         JWT access token obtained from `POST /api/auth/login`.
         Pass as `Authorization: Bearer <token>`.
 
+  parameters:
+    CursorParam:
+      name: cursor
+      in: query
+      required: false
+      schema:
+        type: string
+      description: |
+        Opaque base64-encoded cursor returned by the previous page as `nextCursor`.
+        Omit on the first request.
+
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        default: 20
+        minimum: 1
+        maximum: 100
+      description: Maximum number of items to return per page (default 20, max 100).
+
+  schemas:
+    PaginatedResponse:
+      type: object
+      description: Generic wrapper for all cursor-paginated list responses.
+      required: [data, nextCursor]
+      properties:
+        data:
+          type: array
+          items: {}
+          description: Page of items.
+        nextCursor:
+          type: string
+          nullable: true
+          description: |
+            Opaque cursor to pass as `?cursor=` on the next request.
+            `null` when there are no more pages.
+
+    PaginatedJobResponse:
+      allOf:
+        - $ref: "#/components/schemas/PaginatedResponse"
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: "#/components/schemas/Job"
+
   schemas:
     LoginRequest:
       type: object
@@ -1188,28 +1229,23 @@ components:
 
     PortfolioResponse:
       type: object
-      required: [userId, totalBalance, positions, pagination]
+      required: [userId, totalBalance, data, nextCursor]
       properties:
         userId:
           type: string
           description: Authenticated wallet address (Stellar G... key).
         totalBalance:
           type: string
-          description: Sum of all underlying balances across positions.
-        positions:
+          description: Sum of all underlying balances across positions in the current page.
+        data:
           type: array
           items:
             $ref: "#/components/schemas/VaultPosition"
-        pagination:
-          $ref: "#/components/schemas/Pagination"
-
-    Pagination:
-      type: object
-      required: [page, pageSize, total]
-      properties:
-        page: { type: integer, example: 1 }
-        pageSize: { type: integer, example: 20 }
-        total: { type: integer, example: 1 }
+          description: Page of vault positions.
+        nextCursor:
+          type: string
+          nullable: true
+          description: Opaque cursor for the next page. `null` when there are no more pages.
 
     YieldSource:
       type: object
@@ -1280,7 +1316,7 @@ components:
 
     YieldStatsResponse:
       type: object
-      required: [workerRunning]
+      required: [workerRunning, data, nextCursor]
       properties:
         workerRunning:
           type: boolean
@@ -1288,12 +1324,16 @@ components:
           type: object
           nullable: true
           additionalProperties: true
-        history:
+        data:
           type: array
-          nullable: true
+          description: Current page of historical run records.
           items:
             type: object
             additionalProperties: true
+        nextCursor:
+          type: string
+          nullable: true
+          description: Opaque cursor for the next page. `null` when there are no more pages.
 
     GasFeeOption:
       type: object
@@ -1327,13 +1367,18 @@ components:
 
     GasHistoryResponse:
       type: object
-      required: [chainId, history]
+      required: [chainId, data, nextCursor]
       properties:
         chainId: { type: integer }
-        history:
+        data:
           type: array
+          description: Current page of gas price samples.
           items:
             $ref: "#/components/schemas/GasPriceEstimate"
+        nextCursor:
+          type: string
+          nullable: true
+          description: Opaque cursor for the next page. `null` when there are no more pages.
 
     WithdrawalRequest:
       type: object


### PR DESCRIPTION
…ts (#525)

- Add paginationMiddleware.ts with buildCursor/parseCursor helpers and paginateArray<T> generic utility (default limit 20, max 100)
- Cursors are opaque base64-encoded '<id>:<timestamp>' strings
- GET /api/v1/gas/history: cursor + limit params, returns { chainId, data, nextCursor }
- GET /api/v1/yield/stats: cursor + limit params, returns { workerRunning, lastRun, data, nextCursor }
- GET /api/v1/queue/dlq: cursor + limit params, returns { data, nextCursor }
- GET /api/v1/queue/dashboard: waiting list is cursor-paginated, exposes nextCursor
- GET /api/v1/user/portfolio: replaced page/pageSize with cursor/limit
- Empty pages return empty data array, never 404
- OpenAPI spec updated: CursorParam + LimitParam reusable parameters, PaginatedResponse + PaginatedJobResponse schemas, all paginated endpoints updated


closes #525 