### PR TITLE
feat(k8s): implement GitOps workflow with ArgoCD app-of-apps (#515)

### DIFF
--- a/k8s/argocd/app-of-apps.yaml
+++ b/k8s/argocd/app-of-apps.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aura-vault-app-of-apps
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: aura-vault-protocol
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/soterika/aura-vault-protocol
+    targetRevision: main
+    path: k8s/argocd/apps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/argocd/apps/production.yaml
+++ b/k8s/argocd/apps/production.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aura-vault-production
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: aura-vault-protocol
+    environment: production
+  annotations:
+    # Grafana sync-status annotation — scraped by the monitoring dashboard
+    notifications.argoproj.io/subscribe.on-sync-succeeded.grafana: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.grafana: ""
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/soterika/aura-vault-protocol
+    targetRevision: main
+    path: k8s
+    directory:
+      exclude: "argocd/**"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: aura-vault
+  # Production: NO automated sync — all deployments require manual approval in ArgoCD UI
+  # To deploy: ArgoCD UI → aura-vault-production → Sync → Synchronize
+  # To rollback: argocd app rollback aura-vault-production <revision>
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+  revisionHistoryLimit: 20

--- a/k8s/argocd/apps/staging.yaml
+++ b/k8s/argocd/apps/staging.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aura-vault-staging
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: aura-vault-protocol
+    environment: staging
+  annotations:
+    # Grafana sync-status annotation — scraped by the monitoring dashboard
+    notifications.argoproj.io/subscribe.on-sync-succeeded.grafana: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.grafana: ""
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/soterika/aura-vault-protocol
+    targetRevision: main
+    path: k8s
+    # Exclude the argocd sub-directory to prevent self-referential sync
+    directory:
+      exclude: "argocd/**"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: aura-vault-staging
+  syncPolicy:
+    # Staging: fully automated — every push to main deploys immediately
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+  revisionHistoryLimit: 10

--- a/k8s/argocd/install.md
+++ b/k8s/argocd/install.md
@@ -1,0 +1,73 @@
+# ArgoCD GitOps Setup
+
+## Install ArgoCD into the cluster
+
+```bash
+# 1. Create namespace and install ArgoCD
+kubectl apply -f k8s/argocd/namespace.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+# 2. Wait for ArgoCD to be ready
+kubectl wait --for=condition=available --timeout=120s deployment/argocd-server -n argocd
+
+# 3. Get the initial admin password
+kubectl get secret argocd-initial-admin-secret -n argocd \
+  -o jsonpath='{.data.password}' | base64 -d && echo
+
+# 4. Port-forward to access the ArgoCD UI locally
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+# Open https://localhost:8080 — login with admin / <password from step 3>
+```
+
+## Bootstrap the App-of-Apps
+
+```bash
+# Login to ArgoCD CLI
+argocd login localhost:8080 --insecure --username admin
+
+# Apply the root app-of-apps — this registers all child apps
+kubectl apply -f k8s/argocd/app-of-apps.yaml
+
+# Trigger initial sync of the app-of-apps
+argocd app sync aura-vault-app-of-apps
+
+# The child apps (staging + production) are now registered.
+# Staging will auto-sync; production waits for manual approval.
+```
+
+## Sync Behaviour
+
+| Environment | Namespace          | Sync Mode                        |
+|-------------|--------------------|----------------------------------|
+| Staging     | `aura-vault-staging` | Automatic on every `main` push |
+| Production  | `aura-vault`        | Manual via ArgoCD UI/CLI        |
+
+### Manually sync production
+
+```bash
+# Via CLI
+argocd app sync aura-vault-production
+
+# Or in the ArgoCD UI:
+# Apps → aura-vault-production → Sync → Synchronize
+```
+
+## Rollback via ArgoCD History
+
+```bash
+# List available revisions
+argocd app history aura-vault-production
+
+# Rollback to a specific revision (ID shown by 'history' command)
+argocd app rollback aura-vault-production <revision-id>
+
+# Monitor rollback status
+argocd app wait aura-vault-production --sync
+```
+
+## Grafana Sync-Status Dashboard
+
+ArgoCD notification annotations on each Application manifest
+(`notifications.argoproj.io/subscribe.*`) feed sync events to Grafana.
+The existing `monitoring/grafana/dashboards/system-health.json` dashboard
+can be extended with an ArgoCD datasource panel to visualise sync status.

--- a/k8s/argocd/namespace.yaml
+++ b/k8s/argocd/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd
+  labels:
+    app.kubernetes.io/part-of: aura-vault-protocol


### PR DESCRIPTION
- Add ArgoCD namespace manifest
- Add app-of-apps root Application pointing to k8s/argocd/apps/
- Add staging Application: auto-sync (prune + selfHeal) from main branch
- Add production Application: manual sync only (no automated syncPolicy)
- Grafana notification annotations on both Application manifests
- Add install.md with ArgoCD setup, bootstrap, and rollback instructions

closes #515 