### PR TITLE
feat(k8s): configure resource requests and limits for all pods (#514)

### DIFF
--- a/k8s/backend/deployment.yaml
+++ b/k8s/backend/deployment.yaml
@@ -67,11 +67,11 @@ spec:
                 name: backend-secrets
           resources:
             requests:
-              cpu: "250m"
+              cpu: "100m"
               memory: "256Mi"
             limits:
-              cpu: "1000m"
-              memory: "1Gi"
+              cpu: "500m"
+              memory: "512Mi"
           livenessProbe:
             httpGet:
               path: /api/health

--- a/k8s/database/postgres.yaml
+++ b/k8s/database/postgres.yaml
@@ -94,10 +94,10 @@ spec:
               mountPath: /tmp
           resources:
             requests:
-              cpu: "500m"
+              cpu: "250m"
               memory: "512Mi"
             limits:
-              cpu: "2000m"
+              cpu: "1000m"
               memory: "2Gi"
           livenessProbe:
             exec:

--- a/k8s/database/redis.yaml
+++ b/k8s/database/redis.yaml
@@ -30,7 +30,7 @@ spec:
           resources:
             requests:
               cpu: "50m"
-              memory: "64Mi"
+              memory: "128Mi"
             limits:
               cpu: "200m"
               memory: "256Mi"

--- a/k8s/frontend/deployment.yaml
+++ b/k8s/frontend/deployment.yaml
@@ -60,11 +60,11 @@ spec:
               value: "production"
           resources:
             requests:
-              cpu: "100m"
-              memory: "256Mi"
+              cpu: "50m"
+              memory: "64Mi"
             limits:
-              cpu: "500m"
-              memory: "512Mi"
+              cpu: "200m"
+              memory: "128Mi"
           livenessProbe:
             httpGet:
               path: /

--- a/k8s/limitrange.yaml
+++ b/k8s/limitrange.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: aura-vault-limits
+  namespace: aura-vault
+  labels:
+    app.kubernetes.io/part-of: aura-vault-protocol
+spec:
+  limits:
+    - type: Container
+      # Default requests applied to containers that omit resources.requests
+      defaultRequest:
+        cpu: "100m"
+        memory: "128Mi"
+      # Default limits applied to containers that omit resources.limits
+      default:
+        cpu: "500m"
+        memory: "512Mi"
+      # Hard floor — no container may request less than these
+      min:
+        cpu: "10m"
+        memory: "16Mi"
+      # Hard ceiling — no container may request more than these
+      max:
+        cpu: "2000m"
+        memory: "4Gi"


### PR DESCRIPTION
- Backend: request 100m CPU / 256Mi mem, limit 500m / 512Mi
- Frontend: request 50m CPU / 64Mi mem, limit 200m / 128Mi
- PostgreSQL: request 250m CPU / 512Mi mem, limit 1000m / 2Gi
- Redis: request 50m CPU / 128Mi mem, limit 200m / 256Mi
- Add LimitRange with namespace-wide defaults and min/max bounds

closes #514 