### PR TITLE
ci: implement Trivy container vulnerability scanning with CVE issue c…

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
@@ -56,12 +57,43 @@ jobs:
             type=sha,prefix={{branch}}-
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Backend
-        uses: docker/build-push-action@v5
+      - name: Build Backend image (load for scanning)
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.backend
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
+          load: true
+          tags: backend-scan:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Scan BEFORE pushing — Critical CVEs block the push
+      - name: Trivy scan — backend (CRITICAL blocks push)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: backend-scan:${{ github.sha }}
+          format: sarif
+          output: trivy-backend.sarif
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Upload backend SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-backend.sarif
+          category: trivy-backend-build
+        continue-on-error: true
+
+      - name: Push Backend (only if scan passed)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.backend
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -73,6 +105,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
@@ -99,43 +132,44 @@ jobs:
             type=sha,prefix={{branch}}-
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Frontend
-        uses: docker/build-push-action@v5
+      - name: Build Frontend image (load for scanning)
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.frontend
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
+          load: true
+          tags: frontend-scan:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Scan BEFORE pushing — Critical CVEs block the push
+      - name: Trivy scan — frontend (CRITICAL blocks push)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: frontend-scan:${{ github.sha }}
+          format: sarif
+          output: trivy-frontend.sarif
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Upload frontend SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-frontend.sarif
+          category: trivy-frontend-build
+        continue-on-error: true
+
+      - name: Push Frontend (only if scan passed)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.frontend
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  security-scan:
-    name: Security Scan Docker Images
-    runs-on: ubuntu-latest
-    needs: [build-backend, build-frontend]
-    if: github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run Trivy vulnerability scanner on Backend
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/backend:latest
-          format: 'sarif'
-          output: 'trivy-backend-results.sarif'
-        continue-on-error: true
-
-      - name: Run Trivy vulnerability scanner on Frontend
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend:latest
-          format: 'sarif'
-          output: 'trivy-frontend-results.sarif'
-        continue-on-error: true
-
-      - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-*.sarif'
-        continue-on-error: true

--- a/.github/workflows/trivy-scanning.yml
+++ b/.github/workflows/trivy-scanning.yml
@@ -1,0 +1,378 @@
+name: Trivy Container Vulnerability Scanning
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - 'backend/**'
+      - 'frontend/**'
+      - 'aura-vault/**'
+      - '.github/workflows/trivy-scanning.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'Dockerfile*'
+      - 'docker-compose*.yml'
+      - 'backend/**'
+      - 'frontend/**'
+      - 'aura-vault/**'
+  schedule:
+    # Run weekly on Sunday at 02:00 UTC to catch newly published CVEs
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: trivy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # ── Build & scan all container images ─────────────────────────────────────
+  trivy-scan:
+    name: Build and scan Docker images
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write   # required for SARIF upload
+    outputs:
+      backend-critical: ${{ steps.scan-backend.outputs.critical_count }}
+      frontend-critical: ${{ steps.scan-frontend.outputs.critical_count }}
+      contract-critical: ${{ steps.scan-contract.outputs.critical_count }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # ── Build images ──────────────────────────────────────────────────────
+
+      - name: Build backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.backend
+          push: false
+          load: true
+          tags: aura-backend:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.frontend
+          push: false
+          load: true
+          tags: aura-frontend:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build contract (Wasm) builder image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: aura-contract:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ── Scan backend ──────────────────────────────────────────────────────
+
+      - name: Scan backend — table output
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-backend:${{ github.sha }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          output: trivy-backend-table.txt
+        continue-on-error: true
+
+      - name: Scan backend — JSON output
+        id: scan-backend
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-backend:${{ github.sha }}
+          format: json
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          output: trivy-backend.json
+        continue-on-error: true
+
+      - name: Scan backend — SARIF output (blocks on CRITICAL)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-backend:${{ github.sha }}
+          format: sarif
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          output: trivy-backend.sarif
+
+      # ── Scan frontend ─────────────────────────────────────────────────────
+
+      - name: Scan frontend — table output
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-frontend:${{ github.sha }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          output: trivy-frontend-table.txt
+        continue-on-error: true
+
+      - name: Scan frontend — JSON output
+        id: scan-frontend
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-frontend:${{ github.sha }}
+          format: json
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          output: trivy-frontend.json
+        continue-on-error: true
+
+      - name: Scan frontend — SARIF output (blocks on CRITICAL)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-frontend:${{ github.sha }}
+          format: sarif
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          output: trivy-frontend.sarif
+
+      # ── Scan contract builder ─────────────────────────────────────────────
+
+      - name: Scan contract builder — table output
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-contract:${{ github.sha }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          output: trivy-contract-table.txt
+        continue-on-error: true
+
+      - name: Scan contract builder — JSON output
+        id: scan-contract
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-contract:${{ github.sha }}
+          format: json
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          output: trivy-contract.json
+        continue-on-error: true
+
+      - name: Scan contract builder — SARIF output (blocks on CRITICAL)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: aura-contract:${{ github.sha }}
+          format: sarif
+          severity: CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          output: trivy-contract.sarif
+
+      # ── Upload results ────────────────────────────────────────────────────
+
+      - name: Upload all scan results as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-scan-results-${{ github.sha }}
+          path: |
+            trivy-*.json
+            trivy-*.sarif
+            trivy-*-table.txt
+          retention-days: 30
+
+      - name: Upload backend SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-backend.sarif
+          category: trivy-backend
+        continue-on-error: true
+
+      - name: Upload frontend SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-frontend.sarif
+          category: trivy-frontend
+        continue-on-error: true
+
+      - name: Upload contract SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-contract.sarif
+          category: trivy-contract
+        continue-on-error: true
+
+      - name: Write step summary
+        if: always()
+        run: |
+          echo "## 🔍 Trivy Container Scan Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Backend" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat trivy-backend-table.txt >> "$GITHUB_STEP_SUMMARY" || echo "(no output)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "### Frontend" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat trivy-frontend-table.txt >> "$GITHUB_STEP_SUMMARY" || echo "(no output)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "### Contract Builder" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat trivy-contract-table.txt >> "$GITHUB_STEP_SUMMARY" || echo "(no output)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Auto-create GitHub issues for HIGH CVEs ───────────────────────────────
+  create-issues-for-high-cves:
+    name: Create GitHub issues for HIGH CVEs
+    runs-on: ubuntu-latest
+    needs: trivy-scan
+    if: always()
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download scan results
+        uses: actions/download-artifact@v4
+        with:
+          name: trivy-scan-results-${{ github.sha }}
+          path: ./scan-results
+        continue-on-error: true
+
+      - name: Create GitHub issues for HIGH CVEs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const scanDir = './scan-results';
+            const jsonFiles = ['trivy-backend.json', 'trivy-frontend.json', 'trivy-contract.json'];
+            const imageNames = {
+              'trivy-backend.json': 'backend',
+              'trivy-frontend.json': 'frontend',
+              'trivy-contract.json': 'contract-builder',
+            };
+
+            // Collect all HIGH CVEs (not CRITICAL — those block the build)
+            const highCves = [];
+
+            for (const file of jsonFiles) {
+              const filePath = path.join(scanDir, file);
+              if (!fs.existsSync(filePath)) {
+                console.log(`Skipping missing file: ${file}`);
+                continue;
+              }
+
+              let report;
+              try {
+                report = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+              } catch (e) {
+                console.log(`Could not parse ${file}:`, e.message);
+                continue;
+              }
+
+              const results = report.Results || [];
+              for (const result of results) {
+                const vulns = result.Vulnerabilities || [];
+                for (const vuln of vulns) {
+                  if (vuln.Severity === 'HIGH') {
+                    highCves.push({
+                      cveId: vuln.VulnerabilityID,
+                      pkg: vuln.PkgName,
+                      installedVersion: vuln.InstalledVersion,
+                      fixedVersion: vuln.FixedVersion || 'No fix available',
+                      title: vuln.Title || vuln.VulnerabilityID,
+                      description: vuln.Description || '',
+                      references: (vuln.References || []).slice(0, 3),
+                      image: imageNames[file],
+                      target: result.Target,
+                    });
+                  }
+                }
+              }
+            }
+
+            console.log(`Found ${highCves.length} HIGH CVEs across all images`);
+
+            // Fetch existing open issues to avoid duplicates
+            const { data: existingIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'high-cve',
+              per_page: 100,
+            });
+
+            const existingTitles = new Set(existingIssues.map(i => i.title));
+
+            for (const cve of highCves) {
+              const issueTitle = `[Security] ${cve.cveId} — HIGH CVE in ${cve.image} (${cve.pkg})`;
+
+              if (existingTitles.has(issueTitle)) {
+                console.log(`Issue already exists: ${issueTitle}`);
+                continue;
+              }
+
+              const refs = cve.references.map(r => `- ${r}`).join('\n');
+              const issueBody = [
+                `## ${cve.cveId} — ${cve.title}`,
+                '',
+                `**Severity:** HIGH`,
+                `**Image:** \`${cve.image}\``,
+                `**Target:** \`${cve.target}\``,
+                `**Package:** \`${cve.pkg}\``,
+                `**Installed version:** \`${cve.installedVersion}\``,
+                `**Fixed version:** \`${cve.fixedVersion}\``,
+                `**Detected in commit:** \`${{ github.sha }}\``,
+                '',
+                '### Description',
+                '',
+                cve.description || '_No description available._',
+                '',
+                '### References',
+                '',
+                refs || '_No references._',
+                '',
+                '### Remediation',
+                '',
+                cve.fixedVersion !== 'No fix available'
+                  ? `Update \`${cve.pkg}\` to version \`${cve.fixedVersion}\` or later in the \`${cve.image}\` Docker image.`
+                  : `No fix is currently available for \`${cve.pkg}\`. Monitor the CVE for updates and consider mitigating controls.`,
+                '',
+                '---',
+                '_This issue was automatically created by the [Trivy Container Scanning](.github/workflows/trivy-scanning.yml) workflow._',
+              ].join('\n');
+
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: ['security', 'high-cve', 'automated'],
+              });
+
+              console.log(`Created issue: ${issueTitle}`);
+            }

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM node:20-alpine AS builder
+# Builder image pinned to a specific digest for supply-chain safety.
+FROM node:20-alpine@sha256:a8840bcb3f9a4be7c24c77e17e84e7dbad5efda5dfca82c1ea8df1ca29efed9c AS builder
 
 WORKDIR /app
 
@@ -23,7 +24,10 @@ WORKDIR /app/backend
 RUN npm run build
 
 # ── Runtime stage ────────────────────────────────────────────────────────────
-FROM node:20-alpine
+# Base image is pinned to a specific digest to prevent supply-chain attacks
+# via mutable tags (e.g. a compromised "latest" or "20-alpine" tag).
+# To update: docker pull node:20-alpine && docker inspect --format='{{index .RepoDigests 0}}' node:20-alpine
+FROM node:20-alpine@sha256:a8840bcb3f9a4be7c24c77e17e84e7dbad5efda5dfca82c1ea8df1ca29efed9c
 
 WORKDIR /app
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM node:20-alpine AS builder
+# Builder image pinned to a specific digest for supply-chain safety.
+FROM node:20-alpine@sha256:a8840bcb3f9a4be7c24c77e17e84e7dbad5efda5dfca82c1ea8df1ca29efed9c AS builder
 
 WORKDIR /app
 
@@ -23,7 +24,10 @@ WORKDIR /app/frontend
 RUN npm run build
 
 # ── Runtime stage ────────────────────────────────────────────────────────────
-FROM node:20-alpine
+# Base image pinned to a specific digest to prevent supply-chain attacks via
+# mutable tags. To update, run:
+#   docker pull node:20-alpine && docker inspect --format='{{index .RepoDigests 0}}' node:20-alpine
+FROM node:20-alpine@sha256:a8840bcb3f9a4be7c24c77e17e84e7dbad5efda5dfca82c1ea8df1ca29efed9c
 
 WORKDIR /app
 


### PR DESCRIPTION
 .github/workflows/trivy-scanning.yml — dedicated scanning workflow triggered
  on push/PR and weekly (Sunday 02:00 UTC). Builds all three images (backend,
  frontend, contract builder), scans each in three output formats (table for
  humans, JSON for automation, SARIF for GitHub Security tab). CRITICAL CVEs
  cause a non-zero exit code. A second job create-issues-for-high-cves downloads
  the JSON reports, parses HIGH-severity findings, and creates labelled GitHub
  issues (security, high-cve, automated) — skipping any CVE that already has an
  open issue.
  - .github/workflows/docker-build.yml — rewritten to run Trivy on the
  locally-built image before pushing to the registry, so a CRITICAL CVE blocks
  the push. Action version pinned from @master to @0.28.0.
  - Dockerfile.backend / Dockerfile.frontend — both FROM stages (builder and
  runtime) pinned from the mutable node:20-alpine tag to a specific digest
  (@sha256:a8840bcb…) with an explanatory comment showing how to update the pin.



closes #519 