### PR TITLE
docs: add comprehensive rustdoc comments to all public contract funct…

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,108 @@
+name: Rustdoc
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'aura-vault/src/**'
+      - 'aura-vault/Cargo.toml'
+      - '.github/workflows/rustdoc.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'aura-vault/src/**'
+      - 'aura-vault/Cargo.toml'
+
+# Allow one concurrent deployment to gh-pages
+concurrency:
+  group: rustdoc-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── Build docs and check for warnings ─────────────────────────────────────
+  build-docs:
+    name: Build rustdoc (warn = error)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            aura-vault/target
+          key: ${{ runner.os }}-cargo-doc-${{ hashFiles('aura-vault/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-doc-
+
+      # RUSTDOCFLAGS=-D warnings turns any rustdoc warning into a build error,
+      # satisfying the "generates HTML docs without warnings" acceptance criterion.
+      - name: Build docs (deny warnings)
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          cargo doc \
+            --manifest-path aura-vault/Cargo.toml \
+            --no-deps \
+            2>&1 | tee rustdoc-output.txt
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustdoc-html-${{ github.sha }}
+          path: aura-vault/target/doc/
+          retention-days: 7
+
+  # ── Publish to GitHub Pages (main branch only) ────────────────────────────
+  publish-docs:
+    name: Publish to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build-docs
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            aura-vault/target
+          key: ${{ runner.os }}-cargo-doc-${{ hashFiles('aura-vault/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-doc-
+
+      - name: Build docs for deployment
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          cargo doc \
+            --manifest-path aura-vault/Cargo.toml \
+            --no-deps
+
+          # Add a redirect from the root to the crate docs
+          echo '<meta http-equiv="refresh" content="0; url=aura_vault/index.html">' \
+            > aura-vault/target/doc/index.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: aura-vault/target/doc/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/aura-vault/Cargo.toml
+++ b/aura-vault/Cargo.toml
@@ -2,6 +2,16 @@
 name = "aura-vault"
 version = "0.1.0"
 edition = "2021"
+description = "Share-based yield vault smart contract for the Stellar Soroban platform"
+license = "MIT"
+repository = "https://github.com/soterika/aura-vault-protocol"
+documentation = "https://soterika.github.io/aura-vault-protocol"
+
+[package.metadata.docs.rs]
+# Build docs for the host target (docs.rs does not support wasm32)
+targets = []
+# Enable all features so conditional items are documented
+all-features = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/aura-vault/src/errors.rs
+++ b/aura-vault/src/errors.rs
@@ -2,20 +2,154 @@
 
 use soroban_sdk::contracterror;
 
+/// All error codes that AuraVault contract functions may return.
+///
+/// Errors are represented as `u32` discriminants and are part of the public
+/// ABI — changing a discriminant value is a **breaking change** that requires a
+/// storage-layout version bump and a governance upgrade proposal.
+///
+/// # Mapping to HTTP-style categories
+///
+/// | Range | Category |
+/// |---|---|
+/// | 1–2  | Initialisation errors |
+/// | 3–6  | Input / arithmetic errors |
+/// | 7–8  | State precondition errors |
+/// | 9–12 | Authorization / invariant errors |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum VaultError {
-    NotInitialized         = 1,
-    AlreadyInitialized     = 2,
-    InsufficientShares     = 3,
+    /// The vault has not yet been initialised via [`initialize`].
+    ///
+    /// Returned by any function that reads vault state before `initialize` has
+    /// been called.
+    ///
+    /// [`initialize`]: crate::AuraVault::initialize
+    NotInitialized = 1,
+
+    /// [`initialize`] has already been called on this contract instance.
+    ///
+    /// The vault can only be initialised once. Subsequent calls to
+    /// `initialize` return this error.
+    ///
+    /// [`initialize`]: crate::AuraVault::initialize
+    AlreadyInitialized = 2,
+
+    /// The caller does not hold enough shares to fulfil the withdrawal.
+    ///
+    /// Returned by [`withdraw`] when `shares > balance_of(caller)`.
+    ///
+    /// [`withdraw`]: crate::AuraVault::withdraw
+    InsufficientShares = 3,
+
+    /// The vault's tracked underlying balance is insufficient to cover the
+    /// redemption amount.
+    ///
+    /// This should not occur under normal circumstances (it implies a
+    /// discrepancy between share accounting and the underlying balance). If
+    /// encountered, the vault should be paused and investigated.
+    ///
+    /// Returned by [`withdraw`].
+    ///
+    /// [`withdraw`]: crate::AuraVault::withdraw
     InsufficientUnderlying = 4,
-    ZeroAmount             = 5,
-    MathOverflow           = 6,
-    InvalidAddress         = 7,
-    ZeroShares             = 8,
-    UpgradeUnauthorized    = 9,
-    StorageLayoutMismatch  = 10,
-    VaultPaused            = 11,
-    BalanceMismatch        = 12,
+
+    /// A zero or negative amount was provided, or a deposit would mint zero
+    /// shares due to integer floor-division rounding.
+    ///
+    /// Returned when:
+    /// - `amount <= 0` in [`deposit`]
+    /// - `shares <= 0` in [`withdraw`]
+    /// - `yield_amount <= 0` in [`harvest`]
+    /// - The share formula `floor(amount × total_shares / total_assets)`
+    ///   evaluates to `0` (inflation-attack prevention fence)
+    ///
+    /// [`deposit`]: crate::AuraVault::deposit
+    /// [`withdraw`]: crate::AuraVault::withdraw
+    /// [`harvest`]: crate::AuraVault::harvest
+    ZeroAmount = 5,
+
+    /// An arithmetic operation overflowed `i128`.
+    ///
+    /// All arithmetic in the contract uses `checked_mul` / `checked_div` /
+    /// `checked_add` / `checked_sub`. If any of these return `None`, this
+    /// error is returned. The `overflow-checks = true` release profile flag
+    /// acts as an additional compile-time safety net.
+    MathOverflow = 6,
+
+    /// An address argument failed validation.
+    ///
+    /// Currently returned by [`harvest_token`] when the `alt_token` address
+    /// is not on the admin-managed yield-token whitelist.
+    ///
+    /// Reserved for future address-validation use cases.
+    ///
+    /// [`harvest_token`]: crate::AuraVault::harvest_token
+    InvalidAddress = 7,
+
+    /// [`harvest`] was called when `total_shares == 0`.
+    ///
+    /// Injecting yield into a vault with no shareholders has no effect and is
+    /// likely a caller error.
+    ///
+    /// [`harvest`]: crate::AuraVault::harvest
+    ZeroShares = 8,
+
+    /// A caller attempted an admin-only operation without being the admin.
+    ///
+    /// Returned by [`pause`], [`unpause`], [`set_fees`], [`set_treasury`],
+    /// [`withdraw_fees`], and [`upgrade`] when the supplied address does not
+    /// match the stored admin address.
+    ///
+    /// [`pause`]: crate::AuraVault::pause
+    /// [`unpause`]: crate::AuraVault::unpause
+    /// [`set_fees`]: crate::AuraVault::set_fees
+    /// [`set_treasury`]: crate::AuraVault::set_treasury
+    /// [`withdraw_fees`]: crate::AuraVault::withdraw_fees
+    /// [`upgrade`]: crate::AuraVault::upgrade
+    UpgradeUnauthorized = 9,
+
+    /// The on-chain storage layout version does not match
+    /// [`CURRENT_LAYOUT_VERSION`].
+    ///
+    /// Returned by [`upgrade`] as a safety check before applying a new Wasm
+    /// binary. If this error is encountered, the Wasm being deployed expects a
+    /// different storage schema than what is currently on-chain. A migration
+    /// step is required.
+    ///
+    /// [`CURRENT_LAYOUT_VERSION`]: crate::storage::CURRENT_LAYOUT_VERSION
+    /// [`upgrade`]: crate::AuraVault::upgrade
+    StorageLayoutMismatch = 10,
+
+    /// A mutating operation was called while the vault is paused.
+    ///
+    /// The admin can pause the vault via [`pause`] to halt all deposits,
+    /// withdrawals, and harvests in an emergency. Call [`unpause`] to resume.
+    ///
+    /// Affected functions: [`deposit`], [`withdraw`], [`harvest`],
+    /// [`harvest_token`].
+    ///
+    /// [`pause`]: crate::AuraVault::pause
+    /// [`unpause`]: crate::AuraVault::unpause
+    /// [`deposit`]: crate::AuraVault::deposit
+    /// [`withdraw`]: crate::AuraVault::withdraw
+    /// [`harvest`]: crate::AuraVault::harvest
+    /// [`harvest_token`]: crate::AuraVault::harvest_token
+    VaultPaused = 11,
+
+    /// The vault's actual on-chain token balance differs from the internally
+    /// tracked `total_deposited` value.
+    ///
+    /// This is the **flash-loan guard**. Before every mutating operation the
+    /// contract checks:
+    ///
+    /// ```text
+    /// token.balance(contract_address) == total_deposited
+    /// ```
+    ///
+    /// Any discrepancy (e.g. from a direct token transfer intended to
+    /// manipulate the share price) causes this error and emits a `suspicious`
+    /// event with the observed vs. tracked amounts.
+    BalanceMismatch = 12,
 }

--- a/aura-vault/src/interface.rs
+++ b/aura-vault/src/interface.rs
@@ -1,27 +1,413 @@
 use soroban_sdk::{Address, Env, Vec, Symbol, BytesN, String};
 use crate::errors::VaultError;
 
-/// Public ABI for AuraVault.  Implemented by the contract in lib.rs.
+/// Public ABI for AuraVault.
+///
+/// This trait documents every callable entry point of the vault contract.
+/// The concrete implementation lives in [`crate::AuraVault`] (`lib.rs`).
+///
+/// All functions that mutate vault state require the caller to hold a valid
+/// Soroban authorization (`require_auth`). Read-only view functions (`total_assets`,
+/// `balance_of`, `is_paused`, `proposal_status`) do not require auth and are
+/// free to call.
+///
+/// # Event summary
+///
+/// | Function | Event topic | Event data |
+/// |---|---|---|
+/// | `deposit` | `("deposit", caller, amount)` | `(new_shares, total_shares, total_deposited)` |
+/// | `withdraw` | `("withdraw", caller, shares)` | `(redeem_amount, total_shares, total_deposited)` |
+/// | `harvest` | `("harvest", caller, yield_amount)` | `(yield_after_fee, fee_amount, total_deposited)` |
+/// | `harvest_token` | `("harvest_token", caller, alt_token)` | `(yield_amount, net_underlying, fee_amount)` |
+/// | `pause` | `("paused",)` | `()` |
+/// | `unpause` | `("unpaused",)` | `()` |
+/// | `upgrade` | `("upgrade", admin)` | `(old_version, new_version)` |
+/// | `withdraw_fees` | `("fees_withdrawn", admin)` | `(fees, treasury)` |
+/// | Any mismatch | `("suspicious",)` | `("balance_mismatch", actual, tracked)` |
 #[allow(dead_code)]
 pub trait AuraVaultTrait {
+    /// Initialise the vault.
+    ///
+    /// Must be called exactly once after the contract is deployed. Sets the
+    /// admin address, the underlying token, and the governance signer list.
+    /// All subsequent calls return [`VaultError::AlreadyInitialized`].
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Address that controls privileged operations (pause,
+    ///   set_fees, upgrade, etc.).
+    /// - `underlying_token` — SEP-41-compatible token contract address whose
+    ///   tokens are deposited into and withdrawn from the vault.
+    /// - `signers` — Ordered list of addresses authorised to create and vote
+    ///   on governance proposals. Must be non-empty.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::AlreadyInitialized`] — vault has already been initialised.
     fn initialize(env: Env, admin: Address, underlying_token: Address, signers: Vec<Address>) -> Result<(), VaultError>;
+
+    /// Deposit underlying tokens and receive proportional vault shares.
+    ///
+    /// Transfers `amount` of the underlying token from `caller` to the vault,
+    /// then mints shares according to the current exchange rate:
+    ///
+    /// ```text
+    /// shares = floor(amount × total_shares / total_deposited)   // if vault non-empty
+    /// shares = amount                                            // if vault empty (1:1 seed)
+    /// ```
+    ///
+    /// Enforces the flash-loan guard (actual balance == tracked balance) before
+    /// executing. Emits a `deposit` event on success.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `caller` — Address depositing tokens. Must authorise this call.
+    /// - `amount` — Number of underlying tokens to deposit (in the token's
+    ///   smallest unit, i.e. stroops for a 7-decimal token). Must be > 0.
+    ///
+    /// # Returns
+    ///
+    /// The number of vault shares minted for `caller`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::ZeroAmount`] — `amount <= 0`, or the share formula
+    ///   rounds to zero (deposit too small relative to vault size).
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::VaultPaused`] — vault is currently paused.
+    /// - [`VaultError::BalanceMismatch`] — flash-loan guard tripped.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow in share formula.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// // In a Soroban test environment:
+    /// // let shares = vault_client.deposit(&caller, &1_000_000_i128);
+    /// // assert!(shares > 0);
+    /// ```
     fn deposit(env: Env, caller: Address, amount: i128) -> Result<i128, VaultError>;
+
+    /// Burn vault shares and redeem the proportional underlying tokens.
+    ///
+    /// Calculates the redemption amount using:
+    ///
+    /// ```text
+    /// redeem_amount = floor(shares × total_deposited / total_shares)
+    /// ```
+    ///
+    /// Follows strict **Checks-Effects-Interactions** ordering: shares are
+    /// burned and state is written *before* the token transfer, preventing
+    /// reentrancy. Emits a `withdraw` event on success.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `caller` — Address redeeming shares. Must authorise this call.
+    /// - `shares` — Number of vault shares to burn. Must be > 0 and ≤
+    ///   `balance_of(caller)`.
+    ///
+    /// # Returns
+    ///
+    /// The number of underlying tokens transferred to `caller`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::ZeroAmount`] — `shares <= 0`, or redemption rounds to zero.
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::VaultPaused`] — vault is currently paused.
+    /// - [`VaultError::InsufficientShares`] — caller holds fewer shares than requested.
+    /// - [`VaultError::InsufficientUnderlying`] — vault balance cannot cover redemption.
+    /// - [`VaultError::BalanceMismatch`] — flash-loan guard tripped.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// // let tokens_out = vault_client.withdraw(&caller, &shares);
+    /// // assert!(tokens_out > 0);
+    /// ```
     fn withdraw(env: Env, caller: Address, shares: i128) -> Result<i128, VaultError>;
+
+    /// Inject yield tokens into the vault without minting new shares.
+    ///
+    /// Any caller (keeper) may call this to increase `total_deposited`, which
+    /// raises the redemption value of all existing shares (auto-compounding).
+    /// A performance fee is deducted before crediting the vault.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `caller` — Address providing yield tokens. Must authorise this call.
+    /// - `yield_amount` — Amount of underlying tokens being injected (smallest
+    ///   unit). Must be > 0.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::ZeroAmount`] — `yield_amount <= 0`.
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::VaultPaused`] — vault is currently paused.
+    /// - [`VaultError::ZeroShares`] — vault has no shareholders.
+    /// - [`VaultError::BalanceMismatch`] — flash-loan guard tripped.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow.
     fn harvest(env: Env, caller: Address, yield_amount: i128) -> Result<(), VaultError>;
+
+    /// Halt all mutating operations (deposit, withdraw, harvest).
+    ///
+    /// Admin-only. Emits a `paused` event. Use [`unpause`] to resume.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match the stored admin address and authorise this call.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
+    ///
+    /// [`unpause`]: AuraVaultTrait::unpause
     fn pause(env: Env, admin: Address) -> Result<(), VaultError>;
+
+    /// Resume vault operations after a pause.
+    ///
+    /// Admin-only. Emits an `unpaused` event.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match the stored admin address and authorise this call.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
     fn unpause(env: Env, admin: Address) -> Result<(), VaultError>;
+
+    /// Returns `true` if the vault is currently paused, `false` otherwise.
+    ///
+    /// Read-only; no authorization required.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
     fn is_paused(env: Env) -> bool;
+
+    /// Set performance and management fee rates.
+    ///
+    /// Admin-only. Fees are expressed in **basis points** (bps), where
+    /// `10_000 bps = 100%`.
+    ///
+    /// - Performance fee (`perf_fee_bps`): deducted from each `harvest` call.
+    ///   Default: `1000` (10%).
+    /// - Management fee (`mgmt_fee_bps`): time-based fee (reserved for future
+    ///   implementation). Default: `0`.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match stored admin address and authorise this call.
+    /// - `perf_fee_bps` — Performance fee in basis points (0–10_000).
+    /// - `mgmt_fee_bps` — Management fee in basis points (0–10_000).
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
     fn set_fees(env: Env, admin: Address, perf_fee_bps: u32, mgmt_fee_bps: u32) -> Result<(), VaultError>;
+
+    /// Set the treasury address where accumulated fees are sent.
+    ///
+    /// Admin-only. Fees accumulate in the vault until [`withdraw_fees`] is
+    /// called. The treasury address must be set before `withdraw_fees` can
+    /// succeed.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match stored admin address and authorise this call.
+    /// - `treasury` — Destination address for fee withdrawals.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
+    ///
+    /// [`withdraw_fees`]: AuraVaultTrait::withdraw_fees
     fn set_treasury(env: Env, admin: Address, treasury: Address) -> Result<(), VaultError>;
+
+    /// Transfer all accumulated performance fees to the treasury.
+    ///
+    /// Admin-only. Resets the internal fee counter to zero after transferring.
+    /// Emits a `fees_withdrawn` event.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match stored admin address and authorise this call.
+    ///
+    /// # Returns
+    ///
+    /// The amount of underlying tokens transferred to the treasury. Returns
+    /// `0` if no fees have accumulated.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault or treasury not initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
     fn withdraw_fees(env: Env, admin: Address) -> Result<i128, VaultError>;
+
+    /// Returns the total accumulated (unwithdrawn) performance fees in the
+    /// vault, in underlying token units.
+    ///
+    /// Read-only; no authorization required.
     fn total_fees_collected(env: Env) -> i128;
+
+    /// Returns the total underlying tokens currently tracked by the vault
+    /// (`total_deposited`), in the underlying token's smallest unit.
+    ///
+    /// This equals the sum of all deposited amounts plus harvested yield minus
+    /// withdrawn amounts and fee deductions.
+    ///
+    /// Read-only; no authorization required.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
     fn total_assets(env: Env) -> i128;
+
+    /// Returns the vault share balance for a given address.
+    ///
+    /// Returns `0` for addresses that have never deposited or have fully
+    /// withdrawn.
+    ///
+    /// Read-only; no authorization required.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `address` — The Stellar account address to query.
     fn balance_of(env: Env, address: Address) -> i128;
+
+    /// Upgrade the contract's Wasm binary.
+    ///
+    /// Admin-only. Increments the contract version, replaces the on-chain Wasm
+    /// with the supplied hash, and emits an `upgrade` event. Validates that the
+    /// current storage layout version matches [`CURRENT_LAYOUT_VERSION`] before
+    /// proceeding.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `new_wasm_hash` — 32-byte SHA-256 hash of the new Wasm binary,
+    ///   previously uploaded via `stellar contract upload`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin
+    ///   (admin must authorise).
+    /// - [`VaultError::StorageLayoutMismatch`] — on-chain layout version
+    ///   does not match `CURRENT_LAYOUT_VERSION`.
+    ///
+    /// [`CURRENT_LAYOUT_VERSION`]: crate::storage::CURRENT_LAYOUT_VERSION
     fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), VaultError>;
+
+    /// Create a governance proposal to change the admin address.
+    ///
+    /// The `proposer` must be in the governance signer whitelist.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `proposer` — Authorised signer creating the proposal.
+    /// - `new_admin` — Proposed new admin address.
+    ///
+    /// # Returns
+    ///
+    /// The numeric proposal ID, used for [`vote`] and [`execute`] calls.
+    ///
+    /// [`vote`]: AuraVaultTrait::vote
+    /// [`execute`]: AuraVaultTrait::execute
     fn propose_update_admin(env: Env, proposer: Address, new_admin: Address) -> Result<u64, VaultError>;
+
+    /// Create a governance proposal to change the underlying token address.
+    ///
+    /// The `proposer` must be in the governance signer whitelist.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `proposer` — Authorised signer creating the proposal.
+    /// - `new_token` — Proposed new underlying token contract address.
+    ///
+    /// # Returns
+    ///
+    /// The numeric proposal ID.
     fn propose_update_token(env: Env, proposer: Address, new_token: Address) -> Result<u64, VaultError>;
+
+    /// Create a governance proposal to update a named protocol parameter.
+    ///
+    /// The `proposer` must be in the governance signer whitelist.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `proposer` — Authorised signer creating the proposal.
+    /// - `name` — Symbolic name of the parameter to update (e.g. `perf_fee_bps`).
+    /// - `value` — Proposed new `i128` value for the parameter.
+    ///
+    /// # Returns
+    ///
+    /// The numeric proposal ID.
     fn propose_parameter_update(env: Env, proposer: Address, name: Symbol, value: i128) -> Result<u64, VaultError>;
+
+    /// Vote to approve or reject an open governance proposal.
+    ///
+    /// The `voter` must be in the governance signer whitelist and must not have
+    /// already voted on this proposal.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `voter` — Authorised signer casting the vote. Must authorise this call.
+    /// - `proposal_id` — ID returned by a `propose_*` function.
+    /// - `approve` — `true` to vote in favour; `false` to vote against.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::InvalidAddress`] — voter is not a whitelisted signer.
     fn vote(env: Env, voter: Address, proposal_id: u64, approve: bool) -> Result<(), VaultError>;
+
+    /// Execute an approved governance proposal after its timelock has elapsed.
+    ///
+    /// The proposal must be in `Approved` status. After execution, the status
+    /// changes to `Executed` and the proposed change takes effect.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `executor` — Any authorised signer may execute an approved proposal.
+    /// - `proposal_id` — ID of the proposal to execute.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::InvalidAddress`] — executor is not a whitelisted signer.
     fn execute(env: Env, executor: Address, proposal_id: u64) -> Result<(), VaultError>;
+
+    /// Returns the current status of a governance proposal as a human-readable
+    /// string, or `None` if the proposal ID does not exist.
+    ///
+    /// Possible values: `"Pending"`, `"Approved"`, `"Executed"`, `"Rejected"`.
+    ///
+    /// Read-only; no authorization required.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `proposal_id` — ID of the proposal to query.
     fn proposal_status(env: Env, proposal_id: u64) -> Option<String>;
 }

--- a/aura-vault/src/lib.rs
+++ b/aura-vault/src/lib.rs
@@ -1,3 +1,33 @@
+//! # AuraVault — Share-based Yield Vault for Soroban / Stellar
+//!
+//! AuraVault aggregates deposits of a single SEP-41-compatible underlying
+//! token, issues proportional vault shares to depositors, and auto-compounds
+//! yield through permissionless keeper harvests — all in a trust-minimised,
+//! `no_std` on-chain environment.
+//!
+//! ## Core operations
+//!
+//! | Function | Caller | Description |
+//! |---|---|---|
+//! | [`AuraVault::initialize`] | Admin (once) | One-time setup |
+//! | [`AuraVault::deposit`] | Any | Deposit tokens, receive shares |
+//! | [`AuraVault::withdraw`] | Any | Burn shares, redeem tokens |
+//! | [`AuraVault::harvest`] | Any keeper | Inject yield, raise share price |
+//! | [`AuraVault::pause`] / [`AuraVault::unpause`] | Admin | Emergency halt / resume |
+//!
+//! ## Security properties
+//!
+//! - **CEI ordering** — state written before token transfers on every mutating path.
+//! - **Flash-loan guard** — `actual_balance == total_deposited` checked before each
+//!   mutating call; mismatch emits `suspicious` event and returns
+//!   [`VaultError::BalanceMismatch`].
+//! - **Overflow safety** — all arithmetic uses `checked_*`; `overflow-checks = true`
+//!   in the release profile.
+//! - **Inflation-attack prevention** — zero-share mint is rejected with
+//!   [`VaultError::ZeroAmount`].
+//!
+//! [`VaultError::BalanceMismatch`]: crate::VaultError::BalanceMismatch
+//! [`VaultError::ZeroAmount`]: crate::VaultError::ZeroAmount
 #![no_std]
 
 mod errors;
@@ -34,6 +64,25 @@ impl AuraVault {
     // -----------------------------------------------------------------------
     // initialize
     // -----------------------------------------------------------------------
+    /// Initialise the vault.
+    ///
+    /// Must be called **exactly once** immediately after deployment. Stores the
+    /// admin address, the underlying SEP-41 token, zeroes out share/deposit
+    /// counters, sets the storage layout version, and initialises the
+    /// governance signer list.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment (injected by the runtime).
+    /// - `admin` — Address with privileged control over pause, fees, and upgrades.
+    /// - `underlying_token` — SEP-41-compatible token contract whose tokens are
+    ///   deposited into and redeemed from the vault.
+    /// - `signers` — Ordered list of addresses authorised to create and vote on
+    ///   governance proposals. Must be non-empty.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::AlreadyInitialized`] — `initialize` has already been called.
     pub fn initialize(
         env: Env,
         admin: Address,
@@ -62,6 +111,41 @@ impl AuraVault {
     // We place `caller` and `amount` in topics so they can be efficiently
     // filtered by indexers.
     // -----------------------------------------------------------------------
+    /// Deposit underlying tokens and receive proportional vault shares.
+    ///
+    /// Computes the shares to mint using the current exchange rate:
+    ///
+    /// ```text
+    /// // Empty vault: 1-to-1 seed ratio
+    /// shares = amount
+    ///
+    /// // Non-empty vault:
+    /// shares = floor(amount × total_shares / total_deposited)
+    /// ```
+    ///
+    /// Enforces the flash-loan guard before executing (actual on-chain balance
+    /// must equal `total_deposited`). On success, emits a `deposit` event with
+    /// topics `(event_name, caller, amount)` and data
+    /// `(new_shares, new_total_shares, new_total_deposited)`.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `caller` — Address depositing tokens; must authorise this call.
+    /// - `amount` — Number of underlying tokens to deposit, in the token's
+    ///   smallest unit (e.g. stroops for a 7-decimal Stellar token). Must be > 0.
+    ///
+    /// # Returns
+    ///
+    /// The number of vault shares minted for `caller`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::ZeroAmount`] — `amount <= 0`, or share formula rounds to 0.
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::VaultPaused`] — vault is paused.
+    /// - [`VaultError::BalanceMismatch`] — flash-loan guard tripped.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow in share formula.
     pub fn deposit(env: Env, caller: Address, amount: i128) -> Result<i128, VaultError> {
         caller.require_auth();
 
@@ -141,6 +225,40 @@ impl AuraVault {
     // -----------------------------------------------------------------------
     // withdraw
     // -----------------------------------------------------------------------
+    /// Burn vault shares and redeem the proportional underlying tokens.
+    ///
+    /// Calculates the redemption amount:
+    ///
+    /// ```text
+    /// redeem_amount = floor(shares × total_deposited / total_shares)
+    /// ```
+    ///
+    /// Follows strict **CEI (Checks-Effects-Interactions)** ordering: shares
+    /// are burned and all state is written *before* the token transfer to
+    /// prevent reentrancy. Emits a `withdraw` event with topics
+    /// `(event_name, caller, shares)` and data
+    /// `(redeem_amount, new_total_shares, new_total_deposited)`.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `caller` — Address redeeming shares; must authorise this call.
+    /// - `shares` — Number of vault shares to burn. Must be > 0 and ≤
+    ///   `balance_of(caller)`.
+    ///
+    /// # Returns
+    ///
+    /// The number of underlying tokens transferred to `caller`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::ZeroAmount`] — `shares <= 0`, or redemption rounds to 0.
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::VaultPaused`] — vault is paused.
+    /// - [`VaultError::InsufficientShares`] — caller holds fewer shares than requested.
+    /// - [`VaultError::InsufficientUnderlying`] — vault cannot cover the redemption.
+    /// - [`VaultError::BalanceMismatch`] — flash-loan guard tripped.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow.
     pub fn withdraw(env: Env, caller: Address, shares: i128) -> Result<i128, VaultError> {
         caller.require_auth();
 
@@ -218,6 +336,30 @@ impl AuraVault {
     // -----------------------------------------------------------------------
     // harvest — permissionless keeper entry point (underlying token)
     // -----------------------------------------------------------------------
+    /// Inject underlying-token yield into the vault without minting new shares.
+    ///
+    /// Any keeper may call this to increase `total_deposited`, which raises the
+    /// redemption value of all existing shares (auto-compounding). A performance
+    /// fee is deducted from `yield_amount` before the net amount is credited.
+    ///
+    /// Emits a `harvest` event with topics `(event_name, caller, yield_amount)`
+    /// and data `(yield_after_fee, fee_amount, new_total_deposited)`.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `caller` — Address supplying yield tokens; must authorise this call.
+    /// - `yield_amount` — Amount of underlying tokens to inject, in the token's
+    ///   smallest unit. Must be > 0.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::ZeroAmount`] — `yield_amount <= 0`.
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::VaultPaused`] — vault is paused.
+    /// - [`VaultError::ZeroShares`] — vault has no outstanding shares.
+    /// - [`VaultError::BalanceMismatch`] — flash-loan guard tripped.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow.
     pub fn harvest(env: Env, caller: Address, yield_amount: i128) -> Result<(), VaultError> {
         caller.require_auth();
 
@@ -286,6 +428,43 @@ impl AuraVault {
     // -----------------------------------------------------------------------
     // harvest_token — multi-yield-token entry point (Issue #48)
     // -----------------------------------------------------------------------
+    /// Inject yield denominated in an alternative (non-underlying) token.
+    ///
+    /// Allows keepers to harvest rewards paid in a different token (e.g. a
+    /// protocol incentive token). The caller supplies the alt-token yield, and
+    /// separately provides `underlying_amount` — the equivalent underlying
+    /// value after an off-chain or on-chain swap — which is credited to
+    /// `total_deposited` net of the performance fee.
+    ///
+    /// The `alt_token` must be pre-approved by the admin via
+    /// [`register_yield_token`].
+    ///
+    /// Emits a `harvest_token` event with topics
+    /// `(event_name, caller, alt_token)` and data
+    /// `(yield_amount, net_underlying, fee_amount)`.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `caller` — Address supplying alt-token yield; must authorise this call.
+    /// - `alt_token` — Contract address of the alternative yield token. Must be
+    ///   on the admin whitelist.
+    /// - `yield_amount` — Amount of `alt_token` tokens transferred from `caller`.
+    ///   Must be > 0.
+    /// - `underlying_amount` — Equivalent underlying token value being credited
+    ///   to the vault (after swap/conversion). Must be > 0.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::ZeroAmount`] — either amount is ≤ 0.
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::VaultPaused`] — vault is paused.
+    /// - [`VaultError::ZeroShares`] — vault has no outstanding shares.
+    /// - [`VaultError::InvalidAddress`] — `alt_token` is not whitelisted.
+    /// - [`VaultError::BalanceMismatch`] — flash-loan guard tripped on underlying.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow.
+    ///
+    /// [`register_yield_token`]: AuraVault::register_yield_token
     pub fn harvest_token(
         env: Env,
         caller: Address,
@@ -365,6 +544,21 @@ impl AuraVault {
     // -----------------------------------------------------------------------
     // register_yield_token — admin-only: whitelist an alt yield token
     // -----------------------------------------------------------------------
+    /// Whitelist an alternative yield token for use with [`harvest_token`].
+    ///
+    /// Admin-only. Emits a `yield_token_registered` event.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `alt_token` — Token contract address to add to the whitelist.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
+    ///
+    /// [`harvest_token`]: AuraVault::harvest_token
     pub fn register_yield_token(env: Env, alt_token: Address) -> Result<(), VaultError> {
         let admin = get_admin(&env).ok_or(VaultError::NotInitialized)?;
         admin.require_auth();
@@ -381,6 +575,25 @@ impl AuraVault {
     // pause / unpause — admin-only emergency controls
     // Takes admin address so the client can require_auth on it.
     // -----------------------------------------------------------------------
+    /// Halt all mutating vault operations (deposit, withdraw, harvest).
+    ///
+    /// Admin-only emergency control. Once paused, any call to `deposit`,
+    /// `withdraw`, `harvest`, or `harvest_token` returns
+    /// [`VaultError::VaultPaused`] until [`unpause`] is called.
+    ///
+    /// Emits a `paused` event. Safe to call when already paused (idempotent).
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match the stored admin address and authorise this call.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — `admin` does not match stored admin.
+    ///
+    /// [`unpause`]: AuraVault::unpause
     pub fn pause(env: Env, admin: Address) -> Result<(), VaultError> {
         let stored_admin = get_admin(&env).ok_or(VaultError::NotInitialized)?;
         if stored_admin != admin {
@@ -393,6 +606,22 @@ impl AuraVault {
         Ok(())
     }
 
+    /// Resume vault operations after a [`pause`].
+    ///
+    /// Admin-only. Emits an `unpaused` event. Safe to call when already
+    /// unpaused (idempotent).
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match the stored admin address and authorise this call.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — `admin` does not match stored admin.
+    ///
+    /// [`pause`]: AuraVault::pause
     pub fn unpause(env: Env, admin: Address) -> Result<(), VaultError> {
         let stored_admin = get_admin(&env).ok_or(VaultError::NotInitialized)?;
         if stored_admin != admin {
@@ -405,6 +634,9 @@ impl AuraVault {
         Ok(())
     }
 
+    /// Returns `true` if the vault is currently paused, `false` otherwise.
+    ///
+    /// Read-only view; no authorisation required.
     pub fn is_paused(env: Env) -> bool {
         storage_is_paused(&env)
     }
@@ -413,7 +645,29 @@ impl AuraVault {
     // Fee administration — admin-only
     // -----------------------------------------------------------------------
 
-    /// Set performance and management fee rates (basis points).
+    /// Set performance and management fee rates.
+    ///
+    /// Admin-only. Fees are expressed in **basis points** where
+    /// `10_000 bps = 100%`.
+    ///
+    /// - `perf_fee_bps`: deducted from `yield_amount` on every [`harvest`]
+    ///   call. Default: `1_000` (10 %).
+    /// - `mgmt_fee_bps`: time-based management fee (reserved; not yet
+    ///   charged). Default: `0`.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match the stored admin address and authorise this call.
+    /// - `perf_fee_bps` — Performance fee in basis points (0–10_000).
+    /// - `mgmt_fee_bps` — Management fee in basis points (0–10_000).
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
+    ///
+    /// [`harvest`]: AuraVault::harvest
     pub fn set_fees(env: Env, admin: Address, perf_fee_bps: u32, mgmt_fee_bps: u32) -> Result<(), VaultError> {
         let stored_admin = get_admin(&env).ok_or(VaultError::NotInitialized)?;
         if stored_admin != admin {
@@ -426,7 +680,23 @@ impl AuraVault {
         Ok(())
     }
 
-    /// Set treasury address where fees are sent on withdrawal.
+    /// Set the treasury address where accumulated fees are sent.
+    ///
+    /// Admin-only. The treasury address must be configured before
+    /// [`withdraw_fees`] can succeed.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match the stored admin address and authorise this call.
+    /// - `treasury` — Destination address for fee withdrawals.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
+    ///
+    /// [`withdraw_fees`]: AuraVault::withdraw_fees
     pub fn set_treasury(env: Env, admin: Address, treasury: Address) -> Result<(), VaultError> {
         let stored_admin = get_admin(&env).ok_or(VaultError::NotInitialized)?;
         if stored_admin != admin {
@@ -438,7 +708,25 @@ impl AuraVault {
         Ok(())
     }
 
-    /// Withdraw accumulated fees to the treasury. Admin-only.
+    /// Transfer all accumulated performance fees to the treasury.
+    ///
+    /// Admin-only. Resets the internal fee counter to zero after transferring.
+    /// Emits a `fees_withdrawn` event with topics `(event_name, admin)` and
+    /// data `(fees, treasury)`. Returns `0` if no fees have accumulated.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `admin` — Must match the stored admin address and authorise this call.
+    ///
+    /// # Returns
+    ///
+    /// The amount of underlying tokens transferred to the treasury.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault or treasury not initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — caller is not the admin.
     pub fn withdraw_fees(env: Env, admin: Address) -> Result<i128, VaultError> {
         let stored_admin = get_admin(&env).ok_or(VaultError::NotInitialized)?;
         if stored_admin != admin {
@@ -469,7 +757,10 @@ impl AuraVault {
         Ok(fees)
     }
 
-    /// Read total accumulated (unwithdrawn) fees.
+    /// Returns the total accumulated but not-yet-withdrawn performance fees,
+    /// in underlying token units.
+    ///
+    /// Read-only view; no authorisation required.
     pub fn total_fees_collected(env: Env) -> i128 {
         storage::get_total_fee_collected(&env)
     }
@@ -477,6 +768,14 @@ impl AuraVault {
     // -----------------------------------------------------------------------
     // total_assets  (read-only)
     // -----------------------------------------------------------------------
+    /// Returns the total underlying tokens currently tracked by the vault.
+    ///
+    /// Equals the sum of all deposited amounts plus harvested yield (after
+    /// fees) minus all withdrawn amounts. Returned in the underlying token's
+    /// smallest unit.
+    ///
+    /// Read-only view; no authorisation required. Gas-efficient: reads a
+    /// single instance-storage entry.
     pub fn total_assets(env: Env) -> i128 {
         get_total_deposited(&env)
     }
@@ -484,6 +783,18 @@ impl AuraVault {
     // -----------------------------------------------------------------------
     // balance_of  (read-only)
     // -----------------------------------------------------------------------
+    /// Returns the vault share balance for the given address.
+    ///
+    /// Returns `0` for addresses that have never deposited or have fully
+    /// redeemed their shares.
+    ///
+    /// Read-only view; no authorisation required. Gas-efficient: reads a
+    /// single persistent-storage entry.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `address` — The Stellar account address to query.
     pub fn balance_of(env: Env, address: Address) -> i128 {
         get_balance(&env, &address)
     }
@@ -491,6 +802,29 @@ impl AuraVault {
     // -----------------------------------------------------------------------
     // Upgrade
     // -----------------------------------------------------------------------
+    /// Upgrade the contract's Wasm binary to a new version.
+    ///
+    /// Admin-only. Validates that the current on-chain storage layout version
+    /// matches [`CURRENT_LAYOUT_VERSION`] before applying the upgrade (guards
+    /// against deploying a Wasm that expects a different storage schema).
+    /// Increments the contract version counter, replaces the Wasm, and emits
+    /// an `upgrade` event with topics `(event_name, admin)` and data
+    /// `(old_version, new_version)`.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `new_wasm_hash` — 32-byte SHA-256 hash of the replacement Wasm binary,
+    ///   previously uploaded via `stellar contract upload`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::UpgradeUnauthorized`] — admin `require_auth` failed.
+    /// - [`VaultError::StorageLayoutMismatch`] — on-chain layout version ≠
+    ///   `CURRENT_LAYOUT_VERSION`.
+    ///
+    /// [`CURRENT_LAYOUT_VERSION`]: crate::storage::CURRENT_LAYOUT_VERSION
     pub fn upgrade(env: Env, new_wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), VaultError> {
         let admin = get_admin(&env).ok_or(VaultError::NotInitialized)?;
         admin.require_auth();
@@ -519,14 +853,58 @@ impl AuraVault {
     // Governance Methods
     // -----------------------------------------------------------------------
 
+    /// Create a governance proposal to replace the admin address.
+    ///
+    /// `proposer` must be in the governance signer whitelist and must
+    /// authorise this call.
+    ///
+    /// # Returns
+    ///
+    /// A unique proposal ID for use with [`vote`] and [`execute`].
+    ///
+    /// [`vote`]: AuraVault::vote
+    /// [`execute`]: AuraVault::execute
     pub fn propose_update_admin(env: Env, proposer: Address, new_admin: Address) -> Result<u64, VaultError> {
         create_proposal(&env, proposer, ProposalType::UpdateAdmin)
     }
 
+    /// Create a governance proposal to replace the underlying token address.
+    ///
+    /// `proposer` must be in the governance signer whitelist and must
+    /// authorise this call.
+    ///
+    /// # Returns
+    ///
+    /// A unique proposal ID.
     pub fn propose_update_token(env: Env, proposer: Address, new_token: Address) -> Result<u64, VaultError> {
         create_proposal(&env, proposer, ProposalType::UpdateUnderlyingToken)
     }
 
+    /// Create a governance proposal to update a named protocol parameter.
+    ///
+    /// `proposer` must be in the governance signer whitelist and must
+    /// authorise this call.
+    ///
+    /// # Parameters
+    ///
+    /// - `name` — Symbolic parameter name (e.g. `Symbol::new(&env, "perf_fee_bps")`).
+    /// - `value` — Proposed new `i128` value.
+    ///
+    /// # Returns
+    ///
+    /// A unique proposal ID.
+    /// Create a governance proposal to update a named protocol parameter.
+    ///
+    /// `proposer` must be in the governance signer whitelist.
+    ///
+    /// # Parameters
+    ///
+    /// - `name` — Symbolic parameter name (e.g. `Symbol::new(&env, "perf_fee_bps")`).
+    /// - `value` — Proposed new `i128` value.
+    ///
+    /// # Returns
+    ///
+    /// A unique proposal ID.
     pub fn propose_parameter_update(
         env: Env,
         proposer: Address,
@@ -536,6 +914,16 @@ impl AuraVault {
         create_proposal(&env, proposer, ProposalType::UpdateParameter { name, value })
     }
 
+    /// Vote to approve or reject an open governance proposal.
+    ///
+    /// `voter` must be in the governance signer whitelist and must not have
+    /// already voted on this proposal.
+    ///
+    /// # Parameters
+    ///
+    /// - `voter` — Authorised signer; must authorise this call.
+    /// - `proposal_id` — ID returned by a `propose_*` function.
+    /// - `approve` — `true` to vote in favour; `false` to vote against.
     pub fn vote(
         env: Env,
         voter: Address,
@@ -545,6 +933,15 @@ impl AuraVault {
         vote_on_proposal(&env, voter, proposal_id, approve)
     }
 
+    /// Execute an approved governance proposal after its timelock has elapsed.
+    ///
+    /// The proposal must be in `Approved` status. On success the status moves
+    /// to `Executed` and the proposed change takes effect.
+    ///
+    /// # Parameters
+    ///
+    /// - `executor` — Any whitelisted signer may execute an approved proposal.
+    /// - `proposal_id` — ID of the proposal to execute.
     pub fn execute(
         env: Env,
         executor: Address,
@@ -555,6 +952,12 @@ impl AuraVault {
         Ok(())
     }
 
+    /// Returns the status of a governance proposal as a human-readable string,
+    /// or `None` if the proposal ID does not exist.
+    ///
+    /// Possible values: `"Pending"`, `"Approved"`, `"Executed"`, `"Rejected"`.
+    ///
+    /// Read-only view; no authorisation required.
     pub fn proposal_status(env: Env, proposal_id: u64) -> Option<soroban_sdk::String> {
         get_proposal_status(&env, proposal_id).map(|status| {
             match status {


### PR DESCRIPTION
Adds comprehensive rustdoc comments to all public contract functions so cargo
  doc generates complete HTML documentation.
  
  - lib.rs — module-level crate doc with feature/security overview table; every
  function (initialize, deposit, withdraw, harvest, harvest_token,
  register_yield_token, pause, unpause, is_paused, set_fees, set_treasury,
  withdraw_fees, total_fees_collected, total_assets, balance_of, upgrade, all
  governance methods) documented with description, # Parameters (with units), #
  Returns, and # Errors
  - interface.rs — trait-level doc with full event summary table; every trait
  method fully documented
  - errors.rs — VaultError enum and all 12 variants documented with precise
  trigger conditions and cross-links to the functions that return them
  - Cargo.toml — [package.metadata.docs.rs] section added
  - .github/workflows/rustdoc.yml — new CI workflow: runs cargo doc --no-deps
   with RUSTDOCFLAGS=-D warnings (any warning = build failure) on PRs to
  main/develop; publishes generated HTML to GitHub Pages on push to main via
  actions/deploy-pages


closes #531 