### PR TITLE
feat(#321): add retry logic with exponential backoff for Horizon

### DIFF
--- a/backend/src/services/horizonRetryService.test.ts
+++ b/backend/src/services/horizonRetryService.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for horizonRetryService — Issue #321
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  submitWithRetry,
+  isRetryable,
+  backoffDelayMs,
+  TERMINAL_ERROR_CODES,
+  RETRYABLE_ERROR_CODES,
+  MAX_RETRIES,
+  BASE_DELAY_MS,
+  type HorizonTransactionResult,
+  type HorizonSubmitter,
+} from "./horizonRetryService.js";
+
+const NO_SLEEP = async (_ms: number) => {};  // skip real waits in tests
+
+const FAKE_XDR = "AAAA...base64xdr";
+
+// ---------------------------------------------------------------------------
+// backoffDelayMs
+// ---------------------------------------------------------------------------
+
+describe("backoffDelayMs", () => {
+  it("returns 1s for attempt 1", () => expect(backoffDelayMs(1)).toBe(1_000));
+  it("returns 2s for attempt 2", () => expect(backoffDelayMs(2)).toBe(2_000));
+  it("returns 4s for attempt 3", () => expect(backoffDelayMs(3)).toBe(4_000));
+});
+
+// ---------------------------------------------------------------------------
+// isRetryable
+// ---------------------------------------------------------------------------
+
+describe("isRetryable", () => {
+  it("returns true for network errors", () => {
+    expect(isRetryable({ networkError: true })).toBe(true);
+  });
+
+  it("returns true for HTTP 503", () => {
+    expect(isRetryable({ httpStatus: 503 })).toBe(true);
+  });
+
+  it("returns true for tx_too_late", () => {
+    expect(isRetryable({ resultCode: "tx_too_late" })).toBe(true);
+  });
+
+  it("returns false for tx_bad_auth (terminal)", () => {
+    expect(isRetryable({ resultCode: "tx_bad_auth" })).toBe(false);
+  });
+
+  it("returns false for tx_insufficient_balance (terminal)", () => {
+    expect(isRetryable({ resultCode: "tx_insufficient_balance" })).toBe(false);
+  });
+
+  it("returns false for tx_bad_seq (terminal)", () => {
+    expect(isRetryable({ resultCode: "tx_bad_seq" })).toBe(false);
+  });
+
+  it("returns true for unknown result code (fail open)", () => {
+    expect(isRetryable({ resultCode: "tx_unknown_future_code" })).toBe(true);
+  });
+
+  it("returns true when no result code present", () => {
+    expect(isRetryable({})).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitWithRetry — happy path
+// ---------------------------------------------------------------------------
+
+describe("submitWithRetry — success", () => {
+  it("returns success on first attempt when hash is returned", async () => {
+    const submit: HorizonSubmitter = vi.fn().mockResolvedValue({ hash: "txhash123" });
+    const result = await submitWithRetry(FAKE_XDR, submit, undefined, NO_SLEEP);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.hash).toBe("txhash123");
+      expect(result.attempts).toBe(1);
+    }
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("succeeds on second attempt after a retryable failure", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockResolvedValueOnce({ resultCode: "tx_too_late" })
+      .mockResolvedValueOnce({ hash: "txhash-retry" });
+
+    const result = await submitWithRetry(FAKE_XDR, submit, undefined, NO_SLEEP);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.attempts).toBe(2);
+    }
+    expect(submit).toHaveBeenCalledTimes(2);
+  });
+
+  it("succeeds on third attempt after two retryable failures", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockResolvedValueOnce({ httpStatus: 503, detail: "unavailable" })
+      .mockResolvedValueOnce({ networkError: true })
+      .mockResolvedValueOnce({ hash: "final-hash" });
+
+    const result = await submitWithRetry(FAKE_XDR, submit, undefined, NO_SLEEP);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.attempts).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitWithRetry — terminal errors
+// ---------------------------------------------------------------------------
+
+describe("submitWithRetry — terminal errors (no retry)", () => {
+  for (const code of TERMINAL_ERROR_CODES) {
+    it(`does not retry on ${code}`, async () => {
+      const submit: HorizonSubmitter = vi.fn().mockResolvedValue({ resultCode: code });
+      const result = await submitWithRetry(FAKE_XDR, submit, undefined, NO_SLEEP);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe(code);
+        expect(result.error.retryable).toBe(false);
+        expect(result.error.attempts).toBe(1);
+      }
+      // Should only call submit once — no retries
+      expect(submit).toHaveBeenCalledTimes(1);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// submitWithRetry — exhausted retries
+// ---------------------------------------------------------------------------
+
+describe("submitWithRetry — exhausted retries", () => {
+  it("fails after MAX_RETRIES with retryable errors", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockResolvedValue({ resultCode: "tx_too_late" });
+
+    const result = await submitWithRetry(FAKE_XDR, submit, undefined, NO_SLEEP);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.attempts).toBe(MAX_RETRIES);
+    }
+    expect(submit).toHaveBeenCalledTimes(MAX_RETRIES);
+  });
+
+  it("fails after MAX_RETRIES on repeated network errors", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const result = await submitWithRetry(FAKE_XDR, submit, undefined, NO_SLEEP);
+
+    expect(result.success).toBe(false);
+    expect(submit).toHaveBeenCalledTimes(MAX_RETRIES);
+  });
+
+  it("calls notifier on terminal failure", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockResolvedValue({ resultCode: "tx_bad_auth" });
+
+    const notify = vi.fn().mockResolvedValue(undefined);
+    await submitWithRetry(FAKE_XDR, submit, notify, NO_SLEEP);
+
+    expect(notify).toHaveBeenCalledOnce();
+    expect(notify.mock.calls[0][0]).toMatchObject({ code: "tx_bad_auth" });
+  });
+
+  it("calls notifier after exhausted retries", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockResolvedValue({ resultCode: "tx_too_late" });
+
+    const notify = vi.fn().mockResolvedValue(undefined);
+    await submitWithRetry(FAKE_XDR, submit, notify, NO_SLEEP);
+
+    expect(notify).toHaveBeenCalledOnce();
+  });
+
+  it("does not call notifier on success", async () => {
+    const submit: HorizonSubmitter = vi.fn().mockResolvedValue({ hash: "ok" });
+    const notify = vi.fn().mockResolvedValue(undefined);
+    await submitWithRetry(FAKE_XDR, submit, notify, NO_SLEEP);
+    expect(notify).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backoff timing
+// ---------------------------------------------------------------------------
+
+describe("submitWithRetry — backoff timing", () => {
+  it("sleeps with correct backoff delays between retries", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockResolvedValueOnce({ resultCode: "tx_too_late" })
+      .mockResolvedValueOnce({ resultCode: "tx_too_late" })
+      .mockResolvedValueOnce({ resultCode: "tx_too_late" });
+
+    const sleepDelays: number[] = [];
+    const sleep = async (ms: number) => { sleepDelays.push(ms); };
+
+    await submitWithRetry(FAKE_XDR, submit, undefined, sleep);
+
+    // Should sleep after attempt 1 (1s) and attempt 2 (2s), not after attempt 3
+    expect(sleepDelays).toEqual([BASE_DELAY_MS, BASE_DELAY_MS * 2]);
+  });
+
+  it("does not sleep on terminal error", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockResolvedValue({ resultCode: "tx_bad_auth" });
+
+    const sleepDelays: number[] = [];
+    const sleep = async (ms: number) => { sleepDelays.push(ms); };
+
+    await submitWithRetry(FAKE_XDR, submit, undefined, sleep);
+
+    expect(sleepDelays).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SubmissionError shape
+// ---------------------------------------------------------------------------
+
+describe("SubmissionError fields", () => {
+  it("includes lastAttemptAt as ISO timestamp", async () => {
+    const submit: HorizonSubmitter = vi
+      .fn()
+      .mockResolvedValue({ resultCode: "tx_bad_auth" });
+
+    const result = await submitWithRetry(FAKE_XDR, submit, undefined, NO_SLEEP);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(new Date(result.error.lastAttemptAt).toISOString()).toBe(
+        result.error.lastAttemptAt
+      );
+    }
+  });
+});

--- a/backend/src/services/horizonRetryService.ts
+++ b/backend/src/services/horizonRetryService.ts
@@ -1,0 +1,185 @@
+/**
+ * Horizon Submission Retry Service — Issue #321
+ *
+ * Wraps Horizon transaction submission with exponential backoff retry:
+ *   - Retry on: network timeout, 503 Service Unavailable, tx_too_late
+ *   - Do NOT retry on: tx_bad_auth, tx_insufficient_balance (terminal errors)
+ *   - Backoff schedule: 1 s → 2 s → 4 s  (max 3 retries)
+ *   - After max retries the error is returned with full details
+ *   - Caller is notified via optional webhook/email on terminal failure
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Horizon result codes for a failed transaction */
+export interface HorizonTransactionResult {
+  /** HTTP status from Horizon */
+  httpStatus?: number;
+  /** Horizon result code string, e.g. "tx_bad_auth" */
+  resultCode?: string;
+  /** Network-level error (e.g. fetch timeout) */
+  networkError?: boolean;
+  /** Human-readable detail */
+  detail?: string;
+  /** Successful transaction hash (when submission succeeds) */
+  hash?: string;
+}
+
+export interface SubmissionError {
+  code: string;
+  message: string;
+  attempts: number;
+  lastAttemptAt: string;
+  retryable: boolean;
+}
+
+export interface SubmissionResult {
+  success: true;
+  hash: string;
+  attempts: number;
+}
+
+export type HorizonSubmissionOutcome = SubmissionResult | { success: false; error: SubmissionError };
+
+/** Callable that submits a signed XDR blob to Horizon */
+export type HorizonSubmitter = (xdr: string) => Promise<HorizonTransactionResult>;
+
+/** Optional notification callback invoked on terminal failure */
+export type FailureNotifier = (error: SubmissionError) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// Retry policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Result codes that should never be retried — the transaction is definitively
+ * rejected by the network and a retry would produce the same failure.
+ */
+export const TERMINAL_ERROR_CODES = new Set([
+  "tx_bad_auth",
+  "tx_insufficient_balance",
+  "tx_bad_seq",
+  "tx_no_account",
+  "tx_insufficient_fee",
+  "tx_bad_minSeqAge",
+  "tx_bad_minSeqLedgerGap",
+]);
+
+/**
+ * Result codes / conditions that are safe to retry.
+ * Anything not in TERMINAL_ERROR_CODES and matching this set is retryable.
+ */
+export const RETRYABLE_ERROR_CODES = new Set([
+  "tx_too_late",
+  "timeout",
+]);
+
+export const MAX_RETRIES = 3;
+export const BASE_DELAY_MS = 1_000;
+
+/** Exponential backoff: 1s, 2s, 4s for attempts 1, 2, 3 */
+export function backoffDelayMs(attempt: number): number {
+  return BASE_DELAY_MS * Math.pow(2, attempt - 1);
+}
+
+/**
+ * Determine whether a Horizon result is retryable.
+ *
+ * Retryable conditions:
+ *   1. Network error (timeout / fetch failure)
+ *   2. HTTP 503 Service Unavailable
+ *   3. Result code is in RETRYABLE_ERROR_CODES
+ *   4. Unknown error codes (we fail open toward retrying, except terminal codes)
+ */
+export function isRetryable(result: HorizonTransactionResult): boolean {
+  if (result.networkError) return true;
+  if (result.httpStatus === 503) return true;
+
+  const code = result.resultCode;
+  if (!code) return true; // unknown error — retry
+
+  if (TERMINAL_ERROR_CODES.has(code)) return false;
+  return true; // includes tx_too_late and other transient failures
+}
+
+// ---------------------------------------------------------------------------
+// Core retry loop
+// ---------------------------------------------------------------------------
+
+/** Inject a sleep function for testability */
+type Sleeper = (ms: number) => Promise<void>;
+const defaultSleep: Sleeper = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Submit a signed transaction XDR to Horizon with exponential backoff retry.
+ *
+ * @param xdr        Signed transaction XDR string
+ * @param submit     Horizon submitter (real or mock)
+ * @param notify     Optional failure notifier (webhook/email)
+ * @param sleep      Injectable sleep for testing (default: real setTimeout)
+ */
+export async function submitWithRetry(
+  xdr: string,
+  submit: HorizonSubmitter,
+  notify?: FailureNotifier,
+  sleep: Sleeper = defaultSleep
+): Promise<HorizonSubmissionOutcome> {
+  let lastResult: HorizonTransactionResult = {};
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const result = await submit(xdr);
+
+      if (result.hash) {
+        // Success
+        return { success: true, hash: result.hash, attempts: attempt };
+      }
+
+      lastResult = result;
+
+      // Check if this failure is retryable
+      if (!isRetryable(result)) {
+        const error: SubmissionError = {
+          code: result.resultCode ?? "unknown",
+          message: result.detail ?? `Terminal error: ${result.resultCode}`,
+          attempts: attempt,
+          lastAttemptAt: new Date().toISOString(),
+          retryable: false,
+        };
+        if (notify) await notify(error).catch(console.error);
+        return { success: false, error };
+      }
+
+      // Retryable — back off before the next attempt (unless it's the last)
+      if (attempt < MAX_RETRIES) {
+        await sleep(backoffDelayMs(attempt));
+      }
+    } catch (err) {
+      // Network-level exception (fetch failed, timeout, etc.)
+      lastResult = {
+        networkError: true,
+        detail: err instanceof Error ? err.message : String(err),
+      };
+
+      if (attempt < MAX_RETRIES) {
+        await sleep(backoffDelayMs(attempt));
+      }
+    }
+  }
+
+  // Exhausted all retries
+  const error: SubmissionError = {
+    code: lastResult.resultCode ?? "max_retries_exceeded",
+    message:
+      lastResult.detail ??
+      `Transaction submission failed after ${MAX_RETRIES} attempts`,
+    attempts: MAX_RETRIES,
+    lastAttemptAt: new Date().toISOString(),
+    retryable: true,
+  };
+
+  if (notify) await notify(error).catch(console.error);
+  return { success: false, error };
+}


### PR DESCRIPTION
- Retry on: network timeout, HTTP 503, tx_too_late, and unknown errors
- No retry on terminal errors: tx_bad_auth, tx_insufficient_balance, tx_bad_seq, tx_no_account, tx_insufficient_fee, etc.
- Backoff schedule: 1s -> 2s -> 4s (max 3 attempts total)
- Returns SubmissionError with code, message, attempts, lastAttemptAt
- Optional FailureNotifier callback invoked on terminal or exhausted failure
- Injectable Sleeper for deterministic testing (zero-delay in tests)
- 29 unit tests covering success paths, terminal errors, exhausted retries, backoff timing, and notifier callback behaviour

closes #321