### PR TITLE
feat(#323): implement Stellar network fee bump transaction support

### DIFF
--- a/backend/src/services/feeBumpService.test.ts
+++ b/backend/src/services/feeBumpService.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for feeBumpService — Issue #323
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createFeeBump,
+  getSponsorshipStats,
+  getAdminSponsorshipReport,
+  DEFAULT_FEE_CONFIG,
+  FEE_CAP_BY_TYPE,
+  type FeeBumpConfig,
+  type FeeBumpBuilder,
+} from "./feeBumpService.js";
+
+// ---------------------------------------------------------------------------
+// Mock Redis
+// ---------------------------------------------------------------------------
+
+const store = new Map<string, string>();
+
+vi.mock("../redis.js", () => ({
+  getRedis: () => ({
+    get: async (key: string) => store.get(key) ?? null,
+    incr: async (key: string) => {
+      const v = parseInt(store.get(key) ?? "0", 10) + 1;
+      store.set(key, String(v));
+      return v;
+    },
+    expire: async () => 1,
+    set: async (key: string, value: string) => { store.set(key, value); return "OK"; },
+    del: async (key: string) => { store.delete(key); return 1; },
+  }),
+}));
+
+const ADDR = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const INNER_XDR = "AAAA...signed_inner_xdr";
+
+const mockBuilder: FeeBumpBuilder = vi.fn().mockResolvedValue("BBBB...fee_bump_xdr");
+
+beforeEach(() => {
+  store.clear();
+  vi.clearAllMocks();
+  // Provide a public key for the fee account
+  process.env.FEE_ACCOUNT_PUBLIC_KEY = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+});
+
+// ---------------------------------------------------------------------------
+// getSponsorshipStats
+// ---------------------------------------------------------------------------
+
+describe("getSponsorshipStats", () => {
+  it("returns 0 count for a new address", async () => {
+    const stats = await getSponsorshipStats(ADDR);
+    expect(stats.sponsoredCount).toBe(0);
+    expect(stats.remainingSponsored).toBe(DEFAULT_FEE_CONFIG.maxSponsoredPerAddress);
+    expect(stats.eligible).toBe(true);
+  });
+
+  it("reflects incremented count", async () => {
+    // Simulate 2 previous sponsored txs
+    store.set(`feebump:count:${ADDR}`, "2");
+    const stats = await getSponsorshipStats(ADDR);
+    expect(stats.sponsoredCount).toBe(2);
+    expect(stats.remainingSponsored).toBe(1);
+    expect(stats.eligible).toBe(true);
+  });
+
+  it("marks address ineligible at limit", async () => {
+    store.set(`feebump:count:${ADDR}`, String(DEFAULT_FEE_CONFIG.maxSponsoredPerAddress));
+    const stats = await getSponsorshipStats(ADDR);
+    expect(stats.eligible).toBe(false);
+    expect(stats.remainingSponsored).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createFeeBump — happy path
+// ---------------------------------------------------------------------------
+
+describe("createFeeBump — success", () => {
+  it("returns fee-bump XDR and increments count", async () => {
+    const result = await createFeeBump(
+      { innerXdr: INNER_XDR, userAddress: ADDR, txType: "deposit" },
+      mockBuilder
+    );
+    expect(result.feeBumpXdr).toBe("BBBB...fee_bump_xdr");
+    expect(result.feeSource).toBe(process.env.FEE_ACCOUNT_PUBLIC_KEY);
+    expect(result.feeStroops).toBe(FEE_CAP_BY_TYPE.deposit);
+    expect(result.sponsoredCount).toBe(1);
+  });
+
+  it("calls builder with correct params", async () => {
+    await createFeeBump(
+      { innerXdr: INNER_XDR, userAddress: ADDR, txType: "deposit" },
+      mockBuilder
+    );
+    expect(mockBuilder).toHaveBeenCalledWith({
+      feeSource: process.env.FEE_ACCOUNT_PUBLIC_KEY,
+      innerXdr: INNER_XDR,
+      maxFeeStroops: FEE_CAP_BY_TYPE.deposit,
+    });
+  });
+
+  it("allows up to maxSponsoredPerAddress transactions", async () => {
+    const max = DEFAULT_FEE_CONFIG.maxSponsoredPerAddress;
+    for (let i = 0; i < max; i++) {
+      await createFeeBump(
+        { innerXdr: INNER_XDR, userAddress: ADDR, txType: "deposit" },
+        mockBuilder
+      );
+    }
+    const stats = await getSponsorshipStats(ADDR);
+    expect(stats.eligible).toBe(false);
+  });
+
+  it("uses per-type fee cap", async () => {
+    const result = await createFeeBump(
+      { innerXdr: INNER_XDR, userAddress: ADDR, txType: "claim" },
+      mockBuilder
+    );
+    expect(result.feeStroops).toBe(FEE_CAP_BY_TYPE.claim);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createFeeBump — error cases
+// ---------------------------------------------------------------------------
+
+describe("createFeeBump — errors", () => {
+  it("throws when address exceeds sponsorship limit", async () => {
+    store.set(`feebump:count:${ADDR}`, String(DEFAULT_FEE_CONFIG.maxSponsoredPerAddress));
+    await expect(
+      createFeeBump({ innerXdr: INNER_XDR, userAddress: ADDR, txType: "deposit" }, mockBuilder)
+    ).rejects.toThrow(/exceeded the fee sponsorship limit/);
+  });
+
+  it("throws when txType is not eligible", async () => {
+    const restrictedConfig: FeeBumpConfig = {
+      ...DEFAULT_FEE_CONFIG,
+      eligibleTypes: new Set(["deposit"]),
+    };
+    await expect(
+      createFeeBump(
+        { innerXdr: INNER_XDR, userAddress: ADDR, txType: "withdrawal" },
+        mockBuilder,
+        restrictedConfig
+      )
+    ).rejects.toThrow(/not eligible for fee sponsorship/);
+  });
+
+  it("throws when FEE_ACCOUNT_PUBLIC_KEY is not set", async () => {
+    delete process.env.FEE_ACCOUNT_PUBLIC_KEY;
+    await expect(
+      createFeeBump({ innerXdr: INNER_XDR, userAddress: ADDR, txType: "deposit" }, mockBuilder)
+    ).rejects.toThrow(/FEE_ACCOUNT_PUBLIC_KEY/);
+  });
+
+  it("respects custom maxSponsoredPerAddress", async () => {
+    const customConfig: FeeBumpConfig = {
+      ...DEFAULT_FEE_CONFIG,
+      maxSponsoredPerAddress: 1,
+    };
+    // First tx succeeds
+    await createFeeBump(
+      { innerXdr: INNER_XDR, userAddress: ADDR, txType: "deposit" },
+      mockBuilder,
+      customConfig
+    );
+    // Second tx fails
+    await expect(
+      createFeeBump(
+        { innerXdr: INNER_XDR, userAddress: ADDR, txType: "deposit" },
+        mockBuilder,
+        customConfig
+      )
+    ).rejects.toThrow(/exceeded/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAdminSponsorshipReport
+// ---------------------------------------------------------------------------
+
+describe("getAdminSponsorshipReport", () => {
+  it("returns zero counts for addresses with no history", async () => {
+    const report = await getAdminSponsorshipReport([ADDR]);
+    expect(report.totalSponsored).toBe(0);
+    expect(report.byAddress[ADDR]).toBe(0);
+  });
+
+  it("aggregates counts across multiple addresses", async () => {
+    const addr2 = "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+    store.set(`feebump:count:${ADDR}`, "2");
+    store.set(`feebump:count:${addr2}`, "1");
+    const report = await getAdminSponsorshipReport([ADDR, addr2]);
+    expect(report.totalSponsored).toBe(3);
+    expect(report.byAddress[ADDR]).toBe(2);
+    expect(report.byAddress[addr2]).toBe(1);
+  });
+
+  it("returns empty report for empty address list", async () => {
+    const report = await getAdminSponsorshipReport([]);
+    expect(report.totalSponsored).toBe(0);
+    expect(report.byAddress).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fee cap constraints
+// ---------------------------------------------------------------------------
+
+describe("fee cap", () => {
+  it("clamps fee to config.maxFeeStroops even if per-type cap is higher", async () => {
+    const tightConfig: FeeBumpConfig = {
+      ...DEFAULT_FEE_CONFIG,
+      maxFeeStroops: 10_000, // tighter than per-type defaults
+    };
+    const result = await createFeeBump(
+      { innerXdr: INNER_XDR, userAddress: ADDR, txType: "deposit" },
+      mockBuilder,
+      tightConfig
+    );
+    expect(result.feeStroops).toBe(10_000);
+  });
+});

--- a/backend/src/services/feeBumpService.ts
+++ b/backend/src/services/feeBumpService.ts
@@ -1,0 +1,234 @@
+/**
+ * Stellar Fee Bump Transaction Service — Issue #323
+ *
+ * Sponsors gas fees for users by wrapping their signed inner transactions
+ * in a fee-bump envelope with the protocol fee account as the source.
+ *
+ * Rules:
+ *   - Fee bump source is the protocol fee account (FEE_ACCOUNT_SECRET env var)
+ *   - Maximum fee is configurable per transaction type
+ *   - Sponsorship is limited to the first 3 transactions per new address
+ *   - Sponsored fee counts are tracked in Redis
+ *   - Sponsored transaction counts are reported (admin dashboard data)
+ */
+
+import { getRedis } from "../redis.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type TxType = "deposit" | "withdrawal" | "claim" | "other";
+
+export interface FeeBumpConfig {
+  /** Maximum fee in stroops (1 XLM = 10_000_000 stroops) the protocol will pay */
+  maxFeeStroops: number;
+  /** Transaction types eligible for fee sponsorship */
+  eligibleTypes: Set<TxType>;
+  /** Maximum number of sponsored transactions per new address */
+  maxSponsoredPerAddress: number;
+}
+
+export interface FeeBumpRequest {
+  /** The user-signed inner transaction XDR */
+  innerXdr: string;
+  /** Wallet address of the user (inner transaction source) */
+  userAddress: string;
+  /** Transaction type for fee-cap lookup */
+  txType: TxType;
+}
+
+export interface FeeBumpResult {
+  /** XDR of the fee-bump envelope, ready for submission to Horizon */
+  feeBumpXdr: string;
+  /** Protocol fee account used as fee-bump source */
+  feeSource: string;
+  /** Actual fee set on the bump envelope (in stroops) */
+  feeStroops: number;
+  /** How many sponsored transactions this address has now used */
+  sponsoredCount: number;
+}
+
+export interface FeeSponsorshipStats {
+  address: string;
+  sponsoredCount: number;
+  remainingSponsored: number;
+  eligible: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Default config
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_FEE_CONFIG: FeeBumpConfig = {
+  maxFeeStroops: 100_000,          // 0.01 XLM per transaction
+  eligibleTypes: new Set(["deposit", "withdrawal", "claim", "other"]),
+  maxSponsoredPerAddress: 3,
+};
+
+/** Per-type fee overrides (in stroops) — override in production via config */
+export const FEE_CAP_BY_TYPE: Record<TxType, number> = {
+  deposit: 100_000,
+  withdrawal: 100_000,
+  claim: 50_000,
+  other: 50_000,
+};
+
+// ---------------------------------------------------------------------------
+// Redis tracking
+// ---------------------------------------------------------------------------
+
+const SPONSORSHIP_NS = "feebump:count:";
+const SPONSORSHIP_TTL_SECONDS = 365 * 24 * 3600; // 1 year
+
+async function getSponsoredCount(address: string): Promise<number> {
+  try {
+    const raw = await getRedis().get(SPONSORSHIP_NS + address);
+    return raw ? parseInt(raw, 10) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function incrementSponsoredCount(address: string): Promise<number> {
+  try {
+    const redis = getRedis();
+    const key = SPONSORSHIP_NS + address;
+    const newCount = await redis.incr(key);
+    // Set TTL only on first increment (key just created)
+    if (newCount === 1) {
+      await redis.expire(key, SPONSORSHIP_TTL_SECONDS);
+    }
+    return newCount;
+  } catch {
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fee bump XDR construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fee-bump envelope XDR.
+ *
+ * In a real integration this function would use the `@stellar/stellar-sdk`
+ * TransactionBuilder.buildFeeBumpTransaction() API.  We provide a typed
+ * placeholder here so the service can be wired up without a live Stellar SDK
+ * dependency in the backend package — callers inject the builder via the
+ * `buildEnvelope` parameter.
+ */
+export type FeeBumpBuilder = (params: {
+  feeSource: string;
+  innerXdr: string;
+  maxFeeStroops: number;
+}) => Promise<string>; // returns the fee-bump XDR
+
+/**
+ * Default builder — swaps in a real SDK call in production.
+ * Throws if called without a real builder to prevent silent no-ops.
+ */
+export const defaultFeeBumpBuilder: FeeBumpBuilder = async () => {
+  throw new Error(
+    "No FeeBumpBuilder provided. " +
+    "Inject a real builder using @stellar/stellar-sdk TransactionBuilder.buildFeeBumpTransaction()"
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether an address is eligible for fee sponsorship and how many
+ * sponsored transactions it has already used.
+ */
+export async function getSponsorshipStats(
+  address: string,
+  config: FeeBumpConfig = DEFAULT_FEE_CONFIG
+): Promise<FeeSponsorshipStats> {
+  const count = await getSponsoredCount(address);
+  return {
+    address,
+    sponsoredCount: count,
+    remainingSponsored: Math.max(0, config.maxSponsoredPerAddress - count),
+    eligible: count < config.maxSponsoredPerAddress,
+  };
+}
+
+/**
+ * Wrap a user-signed inner transaction in a fee-bump envelope.
+ *
+ * Throws if:
+ *   - The address has exceeded the sponsorship limit
+ *   - The transaction type is not eligible
+ *   - The fee account secret is not configured
+ *
+ * @param request      Fee bump parameters
+ * @param buildEnvelope Injectable builder (defaults to throwing placeholder)
+ * @param config        Fee policy configuration
+ */
+export async function createFeeBump(
+  request: FeeBumpRequest,
+  buildEnvelope: FeeBumpBuilder = defaultFeeBumpBuilder,
+  config: FeeBumpConfig = DEFAULT_FEE_CONFIG
+): Promise<FeeBumpResult> {
+  const { innerXdr, userAddress, txType } = request;
+
+  // Validate eligibility
+  if (!config.eligibleTypes.has(txType)) {
+    throw new Error(`Transaction type '${txType}' is not eligible for fee sponsorship`);
+  }
+
+  const stats = await getSponsorshipStats(userAddress, config);
+  if (!stats.eligible) {
+    throw new Error(
+      `Address ${userAddress} has exceeded the fee sponsorship limit ` +
+      `(${config.maxSponsoredPerAddress} transactions)`
+    );
+  }
+
+  // Resolve fee source
+  const feeSource = process.env.FEE_ACCOUNT_PUBLIC_KEY;
+  if (!feeSource) {
+    throw new Error("FEE_ACCOUNT_PUBLIC_KEY environment variable is not set");
+  }
+
+  // Determine the fee cap for this tx type
+  const feeStroops = Math.min(
+    FEE_CAP_BY_TYPE[txType] ?? config.maxFeeStroops,
+    config.maxFeeStroops
+  );
+
+  // Build the fee-bump envelope
+  const feeBumpXdr = await buildEnvelope({ feeSource, innerXdr, maxFeeStroops: feeStroops });
+
+  // Increment the sponsorship counter *after* successful envelope construction
+  const sponsoredCount = await incrementSponsoredCount(userAddress);
+
+  return {
+    feeBumpXdr,
+    feeSource,
+    feeStroops,
+    sponsoredCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Admin reporting helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return total sponsored transaction count across a list of addresses.
+ * Used by the admin dashboard to report fee sponsorship spend.
+ */
+export async function getAdminSponsorshipReport(
+  addresses: string[]
+): Promise<{ totalSponsored: number; byAddress: Record<string, number> }> {
+  const counts = await Promise.all(
+    addresses.map(async (addr) => [addr, await getSponsoredCount(addr)] as [string, number])
+  );
+  const byAddress = Object.fromEntries(counts);
+  const totalSponsored = Object.values(byAddress).reduce((a, b) => a + b, 0);
+  return { totalSponsored, byAddress };
+}


### PR DESCRIPTION
- createFeeBump() wraps user-signed inner XDR in a fee-bump envelope
- Protocol fee account (FEE_ACCOUNT_PUBLIC_KEY env var) is fee source
- Per-type fee caps: deposit/withdrawal=100k stroops, claim/other=50k
- config.maxFeeStroops clamps all per-type caps (overrideable)
- Sponsorship limited to first 3 txs per new address (configurable)
- Sponsored counts tracked in Redis with 1-year TTL
- getSponsorshipStats() returns count, remaining, and eligibility
- getAdminSponsorshipReport() aggregates counts for admin dashboard
- Injectable FeeBumpBuilder for testability (placeholder throws without SDK)
- 15 unit tests covering happy path, eligibility enforcement, fee clamping, admin reporting, and custom sponsorship limits

closes #323