### PR TITLE
chore: add node_modules and package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ Cargo.lock
 .DS_Store
 *.wasm
 
+# Node
+node_modules/
+package-lock.json
+
 *storybook.log
 storybook-static
 


### PR DESCRIPTION
 Add node_modules and package-lock.json to .gitignore
  
  node_modules/ and package-lock.json were missing from .gitignore, causing hundreds of
  dependency files to appear as unstaged changes and pollute git status output.
  
  Changes
  
  - Added node_modules/ to .gitignore to prevent dependency files from being tracked
  - Added package-lock.json to .gitignore (lockfile can be regenerated locally)
  
  Tested
  
  - Confirmed git status no longer surfaces node_modules changes after the update
  
  No functional code changes.

closes #534 