### PR TITLE
feat(api): implement user preferences API with DB persistence (#318)

### DIFF
--- a/backend/migrations/007_create_user_preferences.sql
+++ b/backend/migrations/007_create_user_preferences.sql
@@ -1,0 +1,48 @@
+BEGIN;
+
+-- User preferences table — stores per-user display and notification settings.
+-- Used by GET /api/users/preferences and PATCH /api/users/preferences (Issue #318).
+--
+-- Schema columns:
+--   wallet_address    — Stellar or EVM wallet address (primary identifier)
+--   currency          — display currency code, e.g. "USD", "EUR"
+--   language          — BCP-47 language tag, e.g. "en", "fr"
+--   email_notifications — master toggle for all email notifications
+--   harvest_alerts    — specifically opt in/out of harvest event email alerts
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+  id                   BIGSERIAL    PRIMARY KEY,
+  wallet_address       TEXT         NOT NULL,
+  currency             TEXT         NOT NULL DEFAULT 'USD'
+                         CHECK (char_length(currency) BETWEEN 2 AND 10),
+  language             TEXT         NOT NULL DEFAULT 'en'
+                         CHECK (char_length(language) BETWEEN 2 AND 10),
+  email_notifications  BOOLEAN      NOT NULL DEFAULT TRUE,
+  harvest_alerts       BOOLEAN      NOT NULL DEFAULT TRUE,
+  created_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT user_preferences_wallet_address_unique UNIQUE (wallet_address)
+);
+
+-- Fast lookup by wallet address (covered by the unique constraint, but explicit
+-- for clarity and to support partial-index queries in future).
+CREATE INDEX IF NOT EXISTS idx_user_preferences_wallet_address
+  ON user_preferences (wallet_address);
+
+-- Auto-bump updated_at on every row update.
+CREATE OR REPLACE FUNCTION touch_user_preferences_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_user_preferences_updated_at ON user_preferences;
+CREATE TRIGGER trg_user_preferences_updated_at
+BEFORE UPDATE ON user_preferences
+FOR EACH ROW
+EXECUTE FUNCTION touch_user_preferences_updated_at();
+
+COMMIT;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,6 +31,20 @@ import { warmCache } from "./services/defi.js";
 import { startEmailWorker, stopEmailWorker } from "./services/emailQueue.js";
 import { startYieldWorker, stopYieldWorker } from "./services/yieldWorker.js";
 import { vaultRouter } from "./routes/vaultRoutes.js";
+import { userPreferencesRouter } from "./routes/userPreferencesRoutes.js";
+import {
+  applySecurityHeaders,
+  corsOptions,
+} from "./middleware/securityMiddleware.js";
+import {
+  correlationIdMiddleware,
+  createRequestLogger,
+} from "./logger.js";
+import {
+  validate,
+  loginSchema,
+  refreshSchema,
+} from "./validation.js";
 
 const app = express();
 app.use(cors());
@@ -116,6 +130,8 @@ app.use("/api/v1/gas", gasRouter);
 app.use("/api/v1/yield", yieldRouter);
 app.use("/api/v1/queue", queueRouter);
 app.use("/api/v1/vault", vaultRouter);
+// Issue #318: User preferences — requires authentication
+app.use("/api/users/preferences", authenticate, userPreferencesRouter);
 
 app.get("/api/health", async (_req, res) => {
   const redisHealthy = await pingRedis();

--- a/backend/src/routes/__tests__/userPreferencesRoutes.test.ts
+++ b/backend/src/routes/__tests__/userPreferencesRoutes.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for User Preferences API — Issue #318
+ *
+ * GET  /api/users/preferences  → return preferences (defaults on first GET)
+ * PATCH /api/users/preferences → merge-update preferences
+ *
+ * Uses vitest + supertest.  The DB service and auth middleware are mocked so
+ * tests run fast without a real database or JWT infrastructure.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import app from "../../index.js";
+
+// ─── Mock auth middleware ─────────────────────────────────────────────────────
+// Bypass JWT verification; inject a deterministic subject.
+
+const MOCK_WALLET = "GABC123DEF456GHI789JKL012MNO345PQR678STU901VWX234YZA567BCD";
+
+vi.mock("../../middleware/authMiddleware.js", () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.user = { sub: MOCK_WALLET };
+    next();
+  },
+}));
+
+vi.mock("../../middleware/rateLimitMiddleware.js", () => ({
+  userRateLimiter: () => (_req: any, _res: any, next: any) => next(),
+  authRateLimiter: () => (_req: any, _res: any, next: any) => next(),
+  globalIpRateLimiter: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+// ─── Mock the preferences service ────────────────────────────────────────────
+
+const DEFAULT_PREFS = {
+  address: MOCK_WALLET,
+  currency: "USD",
+  language: "en",
+  emailNotifications: true,
+  harvestAlerts: true,
+};
+
+const mockGetUserPreferences = vi.fn(async (_address: string) => ({ ...DEFAULT_PREFS }));
+const mockUpdateUserPreferences = vi.fn(
+  async (_address: string, updates: Record<string, unknown>) => ({
+    ...DEFAULT_PREFS,
+    ...updates,
+  })
+);
+
+vi.mock("../../services/userPreferencesService.js", () => ({
+  getUserPreferences: (...args: any[]) => mockGetUserPreferences(...args),
+  updateUserPreferences: (...args: any[]) => mockUpdateUserPreferences(...args),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/users/preferences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserPreferences.mockResolvedValue({ ...DEFAULT_PREFS });
+  });
+
+  it("returns 200 with default preferences", async () => {
+    const res = await request(app)
+      .get("/api/users/preferences")
+      .set("Authorization", "Bearer test-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      address: MOCK_WALLET,
+      currency: "USD",
+      language: "en",
+      emailNotifications: true,
+      harvestAlerts: true,
+    });
+  });
+
+  it("calls getUserPreferences with the authenticated wallet address", async () => {
+    await request(app)
+      .get("/api/users/preferences")
+      .set("Authorization", "Bearer test-token");
+
+    expect(mockGetUserPreferences).toHaveBeenCalledOnce();
+    expect(mockGetUserPreferences).toHaveBeenCalledWith(MOCK_WALLET);
+  });
+
+  it("returns all required schema fields", async () => {
+    const res = await request(app)
+      .get("/api/users/preferences")
+      .set("Authorization", "Bearer test-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("address");
+    expect(res.body).toHaveProperty("currency");
+    expect(res.body).toHaveProperty("language");
+    expect(res.body).toHaveProperty("emailNotifications");
+    expect(res.body).toHaveProperty("harvestAlerts");
+  });
+
+  it("returns 500 when the service throws", async () => {
+    mockGetUserPreferences.mockRejectedValueOnce(new Error("DB down"));
+
+    const res = await request(app)
+      .get("/api/users/preferences")
+      .set("Authorization", "Bearer test-token");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty("error");
+  });
+});
+
+describe("PATCH /api/users/preferences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserPreferences.mockResolvedValue({ ...DEFAULT_PREFS });
+    mockUpdateUserPreferences.mockImplementation(
+      async (_address: string, updates: Record<string, unknown>) => ({
+        ...DEFAULT_PREFS,
+        ...updates,
+      })
+    );
+  });
+
+  it("returns 200 with updated preferences when patching currency", async () => {
+    mockUpdateUserPreferences.mockResolvedValueOnce({
+      ...DEFAULT_PREFS,
+      currency: "EUR",
+    });
+
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ currency: "EUR" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe("EUR");
+  });
+
+  it("returns 200 when patching language", async () => {
+    mockUpdateUserPreferences.mockResolvedValueOnce({
+      ...DEFAULT_PREFS,
+      language: "fr",
+    });
+
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ language: "fr" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.language).toBe("fr");
+  });
+
+  it("returns 200 when patching emailNotifications to false", async () => {
+    mockUpdateUserPreferences.mockResolvedValueOnce({
+      ...DEFAULT_PREFS,
+      emailNotifications: false,
+    });
+
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ emailNotifications: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.emailNotifications).toBe(false);
+  });
+
+  it("returns 200 when patching harvestAlerts to false", async () => {
+    mockUpdateUserPreferences.mockResolvedValueOnce({
+      ...DEFAULT_PREFS,
+      harvestAlerts: false,
+    });
+
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ harvestAlerts: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.harvestAlerts).toBe(false);
+  });
+
+  it("returns 200 when patching multiple fields at once", async () => {
+    mockUpdateUserPreferences.mockResolvedValueOnce({
+      ...DEFAULT_PREFS,
+      currency: "GBP",
+      language: "de",
+      harvestAlerts: false,
+    });
+
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ currency: "GBP", language: "de", harvestAlerts: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe("GBP");
+    expect(res.body.language).toBe("de");
+    expect(res.body.harvestAlerts).toBe(false);
+  });
+
+  it("returns 200 with an empty patch body (no-op)", async () => {
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({});
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 for unknown fields (strict schema)", async () => {
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ unknown_field: "value" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when currency is too short", async () => {
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ currency: "X" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when currency is too long", async () => {
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ currency: "TOOLONGCURRENCYCODE" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("returns 400 when emailNotifications is not boolean", async () => {
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ emailNotifications: "yes" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("calls updateUserPreferences with the authenticated wallet address", async () => {
+    await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ currency: "JPY" });
+
+    expect(mockUpdateUserPreferences).toHaveBeenCalledOnce();
+    expect(mockUpdateUserPreferences).toHaveBeenCalledWith(
+      MOCK_WALLET,
+      expect.objectContaining({ currency: "JPY" })
+    );
+  });
+
+  it("returns 500 when the service throws", async () => {
+    mockUpdateUserPreferences.mockRejectedValueOnce(new Error("DB write failed"));
+
+    const res = await request(app)
+      .patch("/api/users/preferences")
+      .set("Authorization", "Bearer test-token")
+      .send({ currency: "EUR" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty("error");
+  });
+});

--- a/backend/src/routes/userPreferencesRoutes.ts
+++ b/backend/src/routes/userPreferencesRoutes.ts
@@ -1,0 +1,105 @@
+/**
+ * User Preferences Routes — Issue #318
+ *
+ * GET  /api/users/preferences   → return current prefs (defaults on first call)
+ * PATCH /api/users/preferences  → merge-update preferences
+ *
+ * Both routes require a valid Bearer token (authenticate middleware).
+ * The authenticated wallet address is taken from req.user.sub — the JWT subject.
+ */
+
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { validate } from "../validation.js";
+import {
+  getUserPreferences,
+  updateUserPreferences,
+} from "../services/userPreferencesService.js";
+
+// ── Validation schema ─────────────────────────────────────────────────────────
+
+/**
+ * All fields are optional so callers may send only the fields they want to change.
+ */
+const patchPreferencesSchema = z
+  .object({
+    currency: z
+      .string()
+      .min(2, "currency must be at least 2 characters")
+      .max(10, "currency must be at most 10 characters")
+      .optional(),
+    language: z
+      .string()
+      .min(2, "language must be at least 2 characters")
+      .max(10, "language must be at most 10 characters")
+      .optional(),
+    emailNotifications: z.boolean().optional(),
+    harvestAlerts: z.boolean().optional(),
+  })
+  .strict();
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+export const userPreferencesRouter = Router();
+
+/**
+ * GET /api/users/preferences
+ *
+ * Returns the current preferences for the authenticated wallet.
+ * If no record exists, defaults are created and returned.
+ *
+ * Response 200:
+ *   { address, currency, language, emailNotifications, harvestAlerts }
+ */
+userPreferencesRouter.get(
+  "/",
+  async (req: Request, res: Response): Promise<void> => {
+    const walletAddress: string = (req as any).user?.sub;
+
+    if (!walletAddress) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    try {
+      const prefs = await getUserPreferences(walletAddress);
+      res.json(prefs);
+    } catch (err) {
+      console.error("[userPreferences] GET error:", err);
+      res.status(500).json({ error: "Failed to retrieve preferences" });
+    }
+  }
+);
+
+/**
+ * PATCH /api/users/preferences
+ *
+ * Merge-updates the preferences for the authenticated wallet.
+ * Unspecified fields retain their current value.
+ *
+ * Request body (all optional):
+ *   { currency?, language?, emailNotifications?, harvestAlerts? }
+ *
+ * Response 200:
+ *   { address, currency, language, emailNotifications, harvestAlerts }
+ */
+userPreferencesRouter.patch(
+  "/",
+  validate(patchPreferencesSchema),
+  async (req: Request, res: Response): Promise<void> => {
+    const walletAddress: string = (req as any).user?.sub;
+
+    if (!walletAddress) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    try {
+      const prefs = await updateUserPreferences(walletAddress, req.body);
+      res.json(prefs);
+    } catch (err) {
+      console.error("[userPreferences] PATCH error:", err);
+      res.status(500).json({ error: "Failed to update preferences" });
+    }
+  }
+);

--- a/backend/src/services/userPreferencesService.ts
+++ b/backend/src/services/userPreferencesService.ts
@@ -1,0 +1,151 @@
+/**
+ * User Preferences Service — Issue #318
+ *
+ * Persists display and notification preferences per wallet address.
+ * Uses the read pool for fetches and write pool for upserts.
+ *
+ * Defaults are applied automatically when a wallet has no row yet (first GET).
+ */
+
+import { getReadPool, getWritePool } from "../db.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** All fields that can be stored / returned for a user's preferences. */
+export interface UserPreferences {
+  /** Wallet address that identifies this preference record. */
+  address: string;
+  /** ISO 4217 currency code, e.g. "USD". */
+  currency: string;
+  /** BCP-47 language tag, e.g. "en". */
+  language: string;
+  /** Master toggle — enable all email notifications. */
+  emailNotifications: boolean;
+  /** Toggle for harvest-event email alerts. */
+  harvestAlerts: boolean;
+}
+
+/** Subset of UserPreferences that callers may supply on a PATCH. */
+export type UserPreferencesUpdate = Partial<
+  Omit<UserPreferences, "address">
+>;
+
+// ── Defaults ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_PREFERENCES: Omit<UserPreferences, "address"> = {
+  currency: "USD",
+  language: "en",
+  emailNotifications: true,
+  harvestAlerts: true,
+};
+
+// ── DB row type (snake_case from Postgres) ────────────────────────────────────
+
+interface PreferencesRow {
+  wallet_address: string;
+  currency: string;
+  language: string;
+  email_notifications: boolean;
+  harvest_alerts: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function rowToPreferences(row: PreferencesRow): UserPreferences {
+  return {
+    address: row.wallet_address,
+    currency: row.currency,
+    language: row.language,
+    emailNotifications: row.email_notifications,
+    harvestAlerts: row.harvest_alerts,
+  };
+}
+
+// ── Service functions ─────────────────────────────────────────────────────────
+
+/**
+ * Retrieve preferences for a wallet address.
+ * If no row exists, defaults are upserted and returned (first-GET creates defaults).
+ */
+export async function getUserPreferences(
+  walletAddress: string
+): Promise<UserPreferences> {
+  const readPool = getReadPool();
+
+  const result = await readPool.query<PreferencesRow>(
+    `SELECT wallet_address, currency, language, email_notifications, harvest_alerts
+       FROM user_preferences
+      WHERE wallet_address = $1
+      LIMIT 1`,
+    [walletAddress]
+  );
+
+  if (result.rows.length > 0) {
+    return rowToPreferences(result.rows[0]);
+  }
+
+  // No row yet — create defaults for this wallet address.
+  return upsertUserPreferences(walletAddress, DEFAULT_PREFERENCES);
+}
+
+/**
+ * Update preferences for a wallet address.
+ * Only the fields supplied in `updates` are changed; others retain their current
+ * value (or defaults if this is the first write for the address).
+ */
+export async function updateUserPreferences(
+  walletAddress: string,
+  updates: UserPreferencesUpdate
+): Promise<UserPreferences> {
+  // Fetch existing preferences first so we can merge with defaults.
+  const existing = await getUserPreferences(walletAddress);
+
+  const merged: Omit<UserPreferences, "address"> = {
+    currency:
+      updates.currency !== undefined ? updates.currency : existing.currency,
+    language:
+      updates.language !== undefined ? updates.language : existing.language,
+    emailNotifications:
+      updates.emailNotifications !== undefined
+        ? updates.emailNotifications
+        : existing.emailNotifications,
+    harvestAlerts:
+      updates.harvestAlerts !== undefined
+        ? updates.harvestAlerts
+        : existing.harvestAlerts,
+  };
+
+  return upsertUserPreferences(walletAddress, merged);
+}
+
+/**
+ * Upsert a complete preferences record for a wallet address.
+ * Uses INSERT … ON CONFLICT … DO UPDATE so it is idempotent.
+ */
+async function upsertUserPreferences(
+  walletAddress: string,
+  prefs: Omit<UserPreferences, "address">
+): Promise<UserPreferences> {
+  const writePool = getWritePool();
+
+  const result = await writePool.query<PreferencesRow>(
+    `INSERT INTO user_preferences
+       (wallet_address, currency, language, email_notifications, harvest_alerts)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (wallet_address) DO UPDATE SET
+       currency            = EXCLUDED.currency,
+       language            = EXCLUDED.language,
+       email_notifications = EXCLUDED.email_notifications,
+       harvest_alerts      = EXCLUDED.harvest_alerts
+     RETURNING wallet_address, currency, language, email_notifications, harvest_alerts`,
+    [
+      walletAddress,
+      prefs.currency,
+      prefs.language,
+      prefs.emailNotifications,
+      prefs.harvestAlerts,
+    ]
+  );
+
+  return rowToPreferences(result.rows[0]);
+}


### PR DESCRIPTION
- Add migration 007 for user_preferences table (address, currency, language, emailNotifications, harvestAlerts) with unique constraint and auto-updated_at trigger
- Add userPreferencesService.ts with getUserPreferences (creates defaults on first GET) and updateUserPreferences (merge-patch)
- Add userPreferencesRoutes.ts with GET and PATCH /api/users/preferences, Zod strict validation on PATCH body
- Wire route into index.ts at /api/users/preferences behind authenticate
- Fix missing imports in index.ts (applySecurityHeaders, corsOptions, correlationIdMiddleware, createRequestLogger, validate, loginSchema, refreshSchema)
- Add 16 tests covering defaults, field presence, each field patch, multi-field patch, empty body, unknown fields, validation errors, and service error handling

Closes #318