### PR TITLE
feat(deploy): implement blue-green deployment strategy (#501)

### DIFF
--- a/.github/workflows/blue-green-deploy.yml
+++ b/.github/workflows/blue-green-deploy.yml
@@ -1,0 +1,320 @@
+name: Blue-Green Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        default: "staging"
+        type: choice
+        options: [staging, production]
+      skip_aws:
+        description: "Skip AWS ALB updates (k8s-only mode)"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Dry run (print actions without executing)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: blue-green-${{ github.event.inputs.environment || 'staging' }}
+  cancel-in-progress: false  # never cancel a blue-green deploy mid-flight
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  AWS_REGION: us-east-1
+
+jobs:
+  # ── Build & Test ─────────────────────────────────────────────────────────
+  build:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-tag: ${{ steps.meta.outputs.version }}
+      image-digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+
+      - name: Log build summary
+        run: |
+          echo "## Build Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image**: \`${{ steps.meta.outputs.tags }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Digest**: \`${{ steps.push.outputs.digest }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Commit**: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Deploy to Staging (blue-green) ───────────────────────────────────────
+  deploy-staging:
+    name: Deploy — Staging
+    runs-on: ubuntu-latest
+    needs: build
+    if: |
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging'))
+    environment:
+      name: staging
+      url: https://staging.aura-vault.xyz
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure kubectl
+        run: |
+          aws eks update-kubeconfig \
+            --region "$AWS_REGION" \
+            --name "${{ secrets.EKS_CLUSTER_NAME_STAGING }}" \
+            --alias staging
+
+      - name: Run blue-green deploy script
+        id: deploy
+        env:
+          IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
+          K8S_NAMESPACE: aura-vault-staging
+          ALB_LISTENER_ARN: ${{ secrets.ALB_LISTENER_ARN_STAGING }}
+          BLUE_TG_ARN: ${{ secrets.BLUE_TG_ARN_STAGING }}
+          GREEN_TG_ARN: ${{ secrets.GREEN_TG_ARN_STAGING }}
+          PREVIEW_HOST: preview.staging.aura-vault.internal
+          PRODUCTION_URL: https://staging.aura-vault.xyz
+          SKIP_AWS: ${{ github.event.inputs.skip_aws || 'false' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          chmod +x scripts/blue-green-deploy.sh scripts/smoke-test.sh
+          bash scripts/blue-green-deploy.sh \
+            --image-tag "$IMAGE_TAG" \
+            --namespace "$K8S_NAMESPACE" \
+            --listener-arn "$ALB_LISTENER_ARN" \
+            --blue-tg-arn "$BLUE_TG_ARN" \
+            --green-tg-arn "$GREEN_TG_ARN" \
+            --preview-host "$PREVIEW_HOST" \
+            --timeout 300 \
+            $([ "$SKIP_AWS" == "true" ] && echo "--skip-aws") \
+            $([ "$DRY_RUN" == "true" ] && echo "--dry-run")
+
+      - name: Log deployment summary
+        if: always()
+        run: |
+          echo "## Staging Deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Environment**: staging" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image**: \`${{ needs.build.outputs.image-tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Status**: \`${{ job.status }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Deployed at**: \`$(date -u)\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Commit**: [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "::error::Staging blue-green deployment failed. Check logs above for details."
+          echo "## ⚠️ Deployment Failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "Automatic rollback was attempted. Verify cluster state manually." >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Cleanup old slot warm-down (30 min after deploy) ────────────────────
+  cleanup-old-slot-staging:
+    name: Cleanup Old Slot — Staging
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    if: success()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure kubectl
+        run: |
+          aws eks update-kubeconfig \
+            --region "${{ env.AWS_REGION }}" \
+            --name "${{ secrets.EKS_CLUSTER_NAME_STAGING }}" \
+            --alias staging
+
+      - name: Wait for rollback window (30 min)
+        run: |
+          echo "Keeping old slot warm for 30-minute rollback window …"
+          sleep 1800  # 30 minutes
+
+      - name: Scale down old slot
+        run: |
+          # Identify the standby slot (inverse of current active)
+          ACTIVE=$(kubectl get service aura-vault-stable \
+            --namespace aura-vault-staging \
+            --output jsonpath='{.metadata.annotations.blue-green/active-slot}')
+          OLD_SLOT=$([[ "$ACTIVE" == "blue" ]] && echo "green" || echo "blue")
+
+          echo "Active slot: ${ACTIVE}"
+          echo "Scaling down old slot: ${OLD_SLOT}"
+
+          kubectl scale deployment aura-vault-"${OLD_SLOT}" \
+            --namespace aura-vault-staging \
+            --replicas=0
+
+          echo "Old slot (${OLD_SLOT}) scaled to 0 after 30-minute warm-down" >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Deploy to Production (manual approval required) ──────────────────────
+  deploy-production:
+    name: Deploy — Production
+    runs-on: ubuntu-latest
+    needs: [build, deploy-staging]
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.environment == 'production'
+    environment:
+      name: production
+      url: https://app.aura-vault.xyz
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure kubectl
+        run: |
+          aws eks update-kubeconfig \
+            --region "$AWS_REGION" \
+            --name "${{ secrets.EKS_CLUSTER_NAME_PRODUCTION }}" \
+            --alias production
+
+      - name: Production pre-flight checks
+        run: |
+          echo "## Production Pre-Flight Checks" >> "$GITHUB_STEP_SUMMARY"
+          echo "- [ ] Staging deployment successful (> 1 hour)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- [ ] No active incidents" >> "$GITHUB_STEP_SUMMARY"
+          echo "- [ ] On-call engineer notified" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Proceeding with production blue-green deploy …" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run blue-green deploy script
+        id: deploy
+        env:
+          IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
+          K8S_NAMESPACE: aura-vault
+          ALB_LISTENER_ARN: ${{ secrets.ALB_LISTENER_ARN_PRODUCTION }}
+          BLUE_TG_ARN: ${{ secrets.BLUE_TG_ARN_PRODUCTION }}
+          GREEN_TG_ARN: ${{ secrets.GREEN_TG_ARN_PRODUCTION }}
+          PREVIEW_HOST: preview.aura-vault.internal
+          PRODUCTION_URL: https://app.aura-vault.xyz
+          SKIP_AWS: ${{ github.event.inputs.skip_aws || 'false' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          chmod +x scripts/blue-green-deploy.sh scripts/smoke-test.sh
+          bash scripts/blue-green-deploy.sh \
+            --image-tag "$IMAGE_TAG" \
+            --namespace "$K8S_NAMESPACE" \
+            --listener-arn "$ALB_LISTENER_ARN" \
+            --blue-tg-arn "$BLUE_TG_ARN" \
+            --green-tg-arn "$GREEN_TG_ARN" \
+            --preview-host "$PREVIEW_HOST" \
+            --timeout 300 \
+            $([ "$SKIP_AWS" == "true" ] && echo "--skip-aws") \
+            $([ "$DRY_RUN" == "true" ] && echo "--dry-run")
+
+      - name: Log production deployment
+        if: always()
+        run: |
+          echo "## 🚀 Production Deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Environment**: production" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image**: \`${{ needs.build.outputs.image-tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Status**: \`${{ job.status }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Deployed at**: \`$(date -u)\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Commit**: [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Send deployment notification
+        if: always()
+        run: |
+          STATUS="${{ job.status }}"
+          EMOJI=$([[ "$STATUS" == "success" ]] && echo "✅" || echo "❌")
+          echo "${EMOJI} Production blue-green deployment: ${STATUS}"
+          # Webhook / Slack notification here if configured
+
+      - name: Alert on failure
+        if: failure()
+        run: |
+          echo "::error::Production blue-green deployment FAILED. Rollback was attempted."
+          echo "## ⚠️ PRODUCTION DEPLOYMENT FAILED" >> "$GITHUB_STEP_SUMMARY"
+          echo "Automatic rollback was attempted. VERIFY CLUSTER STATE IMMEDIATELY." >> "$GITHUB_STEP_SUMMARY"
+          echo "Contact: on-call engineer" >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Cleanup old slot warm-down (production) ──────────────────────────────
+  cleanup-old-slot-production:
+    name: Cleanup Old Slot — Production
+    runs-on: ubuntu-latest
+    needs: deploy-production
+    if: success()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure kubectl
+        run: |
+          aws eks update-kubeconfig \
+            --region "${{ env.AWS_REGION }}" \
+            --name "${{ secrets.EKS_CLUSTER_NAME_PRODUCTION }}" \
+            --alias production
+
+      - name: Wait for rollback window (30 min)
+        run: |
+          echo "Keeping old slot warm for 30-minute rollback window …"
+          sleep 1800
+
+      - name: Scale down old slot
+        run: |
+          ACTIVE=$(kubectl get service aura-vault-stable \
+            --namespace aura-vault \
+            --output jsonpath='{.metadata.annotations.blue-green/active-slot}')
+          OLD_SLOT=$([[ "$ACTIVE" == "blue" ]] && echo "green" || echo "blue")
+
+          echo "Active slot: ${ACTIVE}"
+          echo "Scaling down old slot: ${OLD_SLOT}"
+
+          kubectl scale deployment aura-vault-"${OLD_SLOT}" \
+            --namespace aura-vault \
+            --replicas=0
+
+          echo "Production old slot (${OLD_SLOT}) scaled to 0 after 30-minute warm-down" >> "$GITHUB_STEP_SUMMARY"

--- a/BLUE_GREEN_DEPLOYMENT.md
+++ b/BLUE_GREEN_DEPLOYMENT.md
@@ -1,0 +1,461 @@
+# Blue-Green Deployment
+
+Aura Vault Protocol uses a **blue-green deployment strategy** for all backend
+releases, achieving zero-downtime updates with instant, one-command rollback.
+
+---
+
+## Table of Contents
+
+1. [How It Works](#how-it-works)
+2. [Architecture](#architecture)
+3. [Prerequisites](#prerequisites)
+4. [Running a Deployment](#running-a-deployment)
+5. [Smoke Tests](#smoke-tests)
+6. [Rollback Procedure](#rollback-procedure)
+7. [GitHub Actions Workflow](#github-actions-workflow)
+8. [Terraform Infrastructure](#terraform-infrastructure)
+9. [Kubernetes Manifests](#kubernetes-manifests)
+10. [Secrets Reference](#secrets-reference)
+11. [Troubleshooting](#troubleshooting)
+12. [Acceptance Criteria Mapping](#acceptance-criteria-mapping)
+
+---
+
+## How It Works
+
+```
+         ┌─────────────────────────────────────────────┐
+         │              CI/CD Pipeline                  │
+         └────────────────┬────────────────────────────┘
+                          │  1. Build & push image
+                          ▼
+         ┌─────────────────────────────────────────────┐
+         │           blue-green-deploy.sh               │
+         │                                              │
+         │  2. Detect active slot (e.g. blue)           │
+         │  3. Deploy new image → standby (green)       │
+         │  4. Update preview Service → green           │
+         │  5. Run smoke tests against preview          │
+         │  6. ── if tests PASS ──────────────────────► │
+         │       Patch stable Service → slot:green      │
+         │       Update ALB weights  → 100% green       │
+         │  7. Run post-switch smoke test (production)  │
+         │     ── if tests FAIL → auto-rollback ──────► │
+         │  8. Keep blue warm 30 min (rollback window)  │
+         │  9. Scale blue to 0                          │
+         └─────────────────────────────────────────────┘
+```
+
+At no point is there a period where zero instances are ready.  The old slot
+stays live and fully scaled until the new slot passes all checks.
+
+---
+
+## Architecture
+
+### Kubernetes
+
+| Resource | Name | Purpose |
+|---|---|---|
+| Deployment | `aura-vault-blue` | Blue slot pods |
+| Deployment | `aura-vault-green` | Green slot pods |
+| Service | `aura-vault-stable` | Production traffic (selector points to active slot) |
+| Service | `aura-vault-preview` | Smoke-test traffic (selector always points to standby) |
+| Ingress | `aura-vault-ingress` | External → stable Service |
+| Ingress | `aura-vault-preview-ingress` | Internal-only → preview Service |
+
+The traffic switch is a single atomic `kubectl patch` on `aura-vault-stable`'s
+selector: `slot: blue` ↔ `slot: green`.  No pod restarts, no rolling updates,
+no connection draining race.
+
+### AWS ALB
+
+| Resource | Purpose |
+|---|---|
+| TG `aura-vault-blue-<env>` | Instances in the blue slot |
+| TG `aura-vault-green-<env>` | Instances in the green slot |
+| Listener rule (priority 10, `/api/*`) | Weighted forward — 100/0 or 0/100 |
+| Listener rule (priority 5, `preview.*`) | Always routes to standby slot |
+
+The Terraform `active_slot` variable controls the initial weight on first
+`terraform apply`.  At runtime, `deploy.sh` updates weights via
+`aws elbv2 modify-rule`.
+
+---
+
+## Prerequisites
+
+- `kubectl` configured for the target cluster
+- `aws` CLI with permissions for `elbv2:ModifyRule`, `elbv2:DescribeRules`
+- Docker image pushed to GHCR (`ghcr.io/soterika/aura-vault-protocol:<tag>`)
+- `curl`, `bc` installed on the machine running the deploy script
+
+---
+
+## Running a Deployment
+
+### Via GitHub Actions (recommended)
+
+Push to `main` — staging deploys automatically.
+
+For production:
+
+```
+Actions → Blue-Green Deploy → Run workflow
+  Environment: production
+  skip_aws: false
+  dry_run: false
+```
+
+### Manual (CLI)
+
+```bash
+export IMAGE_TAG="sha-abc1234"
+export K8S_NAMESPACE="aura-vault"
+export ALB_LISTENER_ARN="arn:aws:elasticloadbalancing:..."
+export BLUE_TG_ARN="arn:aws:elasticloadbalancing:..."
+export GREEN_TG_ARN="arn:aws:elasticloadbalancing:..."
+export PRODUCTION_URL="https://app.aura-vault.xyz"
+
+./scripts/blue-green-deploy.sh \
+  --image-tag "$IMAGE_TAG" \
+  --namespace "$K8S_NAMESPACE"
+```
+
+#### Dry run (preview actions without executing)
+
+```bash
+./scripts/blue-green-deploy.sh --image-tag sha-abc1234 --dry-run
+```
+
+#### K8s-only mode (no ALB updates)
+
+```bash
+./scripts/blue-green-deploy.sh --image-tag sha-abc1234 --skip-aws
+```
+
+### What the script does, step by step
+
+| Step | Action | Failure behaviour |
+|---|---|---|
+| 1 | Read active slot from k8s annotation | Defaults to `blue` if missing |
+| 2 | `kubectl set image` on standby deployment | Abort — no traffic changed |
+| 3 | `kubectl rollout status` (timeout 5 min) | Abort — no traffic changed |
+| 4 | Patch preview Service → standby slot | Continue (non-fatal) |
+| 5 | Run `smoke-test.sh` against preview | Abort — no traffic changed |
+| 6 | Patch stable Service selector | — |
+| 6 | Update ALB listener weights | — |
+| 7 | Run `smoke-test.sh` (quick) on production URL | Auto-rollback |
+| 8 | Annotate old deployment (cleanup time) | Non-fatal |
+| 9 | (Async, 30 min later) Scale old slot to 0 | GitHub Actions cleanup job |
+
+---
+
+## Smoke Tests
+
+`scripts/smoke-test.sh` runs in two modes:
+
+**Full mode** (pre-switch, against preview):
+- `GET /api/health` → 200, body contains `status:ok`
+- `GET /api/ready` → 200
+- `x-deployment-slot` header matches expected slot
+- `GET /api/vault/status` → 200
+- `GET /api/vault/apy` → 200 or 401
+- 404 on unknown route (no panic)
+- Security headers: `X-Content-Type-Options`, `X-Frame-Options`
+- No server version disclosure
+- Response latency < 2 s
+- Content-Type: application/json on JSON endpoints
+- CORS preflight (OPTIONS)
+- Metrics endpoint reachable
+
+**Quick mode** (`SMOKE_QUICK=true`, post-switch against production):
+- Health, readiness, vault status, slot header, latency, security headers only
+
+```bash
+# Full run
+SMOKE_TARGET=http://preview.aura-vault.internal ./scripts/smoke-test.sh
+
+# Quick run
+SMOKE_TARGET=https://app.aura-vault.xyz SMOKE_QUICK=true ./scripts/smoke-test.sh
+```
+
+---
+
+## Rollback Procedure
+
+### Instant rollback (< 30 seconds)
+
+The old slot stays at full scale for **30 minutes** after every successful
+deploy.  Within that window:
+
+```bash
+# Option A: re-deploy previous image tag
+./scripts/blue-green-deploy.sh --image-tag <PREVIOUS_TAG>
+
+# Option B: patch the Service selector directly (fastest)
+kubectl patch service aura-vault-stable \
+  --namespace aura-vault \
+  --type merge \
+  --patch '{"spec":{"selector":{"slot":"blue"}},"metadata":{"annotations":{"blue-green/active-slot":"blue"}}}'
+
+# Option C: update ALB weights only (if k8s already looks good)
+aws elbv2 modify-rule \
+  --rule-arn <PRODUCTION_RULE_ARN> \
+  --actions '[{"Type":"forward","ForwardConfig":{"TargetGroups":[{"TargetGroupArn":"<BLUE_TG_ARN>","Weight":100},{"TargetGroupArn":"<GREEN_TG_ARN>","Weight":0}]}}]'
+```
+
+### Automatic rollback
+
+If the post-switch smoke test fails, `blue-green-deploy.sh` automatically:
+
+1. Patches the stable Service selector back to the old slot
+2. Resets the ALB weights to 100% old slot
+3. Exits with code `1` (triggers GitHub Actions failure alert)
+
+### After the 30-minute window
+
+The old slot has been scaled to 0.  A "rollback" becomes a fresh deployment of
+the previous image:
+
+```bash
+./scripts/blue-green-deploy.sh --image-tag <PREVIOUS_TAG>
+```
+
+This takes a normal deployment cycle (~3–5 minutes) instead of being instant.
+
+### Rollback decision tree
+
+```
+Is the old slot still warm (< 30 min since deploy)?
+  YES → Option A/B/C above — takes < 30 s
+  NO  → Re-deploy previous image tag — takes ~5 min
+
+Is the active slot completely down?
+  YES → kubectl scale deployment aura-vault-<ACTIVE> --replicas=3
+        then verify with smoke tests
+  NO  → use rollback procedures above
+```
+
+---
+
+## GitHub Actions Workflow
+
+File: `.github/workflows/blue-green-deploy.yml`
+
+### Triggers
+
+| Trigger | Behaviour |
+|---|---|
+| Push to `main` | Automatic staging deploy |
+| `workflow_dispatch` with `environment=staging` | Manual staging deploy |
+| `workflow_dispatch` with `environment=production` | Manual production deploy (requires approval in the *production* GitHub Environment) |
+
+### Jobs
+
+```
+build → deploy-staging → cleanup-old-slot-staging (30 min delay)
+      ↘
+        deploy-production (manual approval) → cleanup-old-slot-production
+```
+
+### Required Secrets
+
+See [Secrets Reference](#secrets-reference).
+
+### Inputs (workflow_dispatch)
+
+| Input | Default | Description |
+|---|---|---|
+| `environment` | `staging` | `staging` or `production` |
+| `skip_aws` | `false` | Skip ALB weight updates |
+| `dry_run` | `false` | Print without executing |
+
+---
+
+## Terraform Infrastructure
+
+File: `terraform/blue-green.tf`
+
+### What it creates
+
+- `aws_lb_target_group.blue` — Blue slot TG, port 3001, `/api/health` health check
+- `aws_lb_target_group.green` — Green slot TG
+- `aws_lb_listener_rule.blue_green_production` — Priority 10, `/api/*`, weighted forward
+- `aws_lb_listener_rule.blue_green_preview` — Priority 5, host `preview.*`, standby slot only
+- `aws_cloudwatch_metric_alarm.blue_unhealthy_hosts` — Alert on blue slot health
+- `aws_cloudwatch_metric_alarm.green_unhealthy_hosts` — Alert on green slot health
+
+### Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `active_slot` | `blue` | Initial active slot |
+| `blue_green_rollback_window_minutes` | `30` | Stickiness duration |
+| `blue_green_preview_cidr` | `10.0.0.0/8` | Allowed CIDRs for preview rule |
+
+### Outputs
+
+| Output | Description |
+|---|---|
+| `blue_target_group_arn` | Blue TG ARN — use as `BLUE_TG_ARN` secret |
+| `green_target_group_arn` | Green TG ARN — use as `GREEN_TG_ARN` secret |
+| `blue_green_listener_rule_arn` | Production listener rule ARN |
+| `preview_listener_rule_arn` | Preview listener rule ARN |
+
+### Initial setup
+
+```bash
+cd terraform
+terraform init
+terraform plan -var="active_slot=blue"
+terraform apply -var="active_slot=blue"
+
+# Copy outputs to GitHub Secrets
+terraform output blue_target_group_arn
+terraform output green_target_group_arn
+```
+
+> **Note**: After the first live swap, Terraform will show listener rule
+> weight drift — the deploy script is the source of truth for weights at
+> runtime. `terraform apply` resets weights to the `active_slot` variable
+> value, which is useful for disaster recovery.
+
+---
+
+## Kubernetes Manifests
+
+Directory: `k8s/blue-green/`
+
+### Initial cluster setup
+
+```bash
+kubectl apply -f k8s/blue-green/
+```
+
+This creates:
+- Both deployments (scaled to 3 replicas, `Recreate` strategy within each slot)
+- `aura-vault-stable` Service (selector: `slot:blue`)
+- `aura-vault-preview` Service (selector: `slot:green`)
+- Production Ingress (→ stable Service)
+- Preview Ingress (internal, CIDR-restricted → preview Service)
+
+### Checking current state
+
+```bash
+# Which slot is active?
+kubectl get service aura-vault-stable \
+  --namespace aura-vault \
+  --output jsonpath='{.metadata.annotations.blue-green/active-slot}'
+
+# Pod status per slot
+kubectl get pods --namespace aura-vault \
+  --selector app=aura-vault \
+  --show-labels
+
+# Rollout status
+kubectl rollout status deployment/aura-vault-blue --namespace aura-vault
+kubectl rollout status deployment/aura-vault-green --namespace aura-vault
+```
+
+---
+
+## Secrets Reference
+
+Configure these in GitHub → Settings → Secrets and variables → Actions:
+
+| Secret | Description |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | AWS IAM key for EKS + ALB access |
+| `AWS_SECRET_ACCESS_KEY` | AWS IAM secret |
+| `EKS_CLUSTER_NAME_STAGING` | EKS cluster name for staging |
+| `EKS_CLUSTER_NAME_PRODUCTION` | EKS cluster name for production |
+| `ALB_LISTENER_ARN_STAGING` | HTTPS listener ARN (staging) |
+| `ALB_LISTENER_ARN_PRODUCTION` | HTTPS listener ARN (production) |
+| `BLUE_TG_ARN_STAGING` | Blue target group ARN (staging) |
+| `GREEN_TG_ARN_STAGING` | Green target group ARN (staging) |
+| `BLUE_TG_ARN_PRODUCTION` | Blue target group ARN (production) |
+| `GREEN_TG_ARN_PRODUCTION` | Green target group ARN (production) |
+
+All ARN values are available as Terraform outputs after `terraform apply`.
+
+---
+
+## Troubleshooting
+
+### Deployment stuck at rollout
+
+```bash
+kubectl rollout status deployment/aura-vault-green --namespace aura-vault --timeout=10s
+kubectl describe deployment aura-vault-green --namespace aura-vault
+kubectl get events --namespace aura-vault --sort-by='.lastTimestamp' | tail -20
+```
+
+Common causes: image pull failure, OOM on new version, readiness probe failing.
+
+### Smoke tests fail on preview
+
+```bash
+# What does preview actually return?
+curl -v http://preview.aura-vault.internal/api/health
+
+# Check preview Service selector
+kubectl get service aura-vault-preview --namespace aura-vault --output yaml
+
+# Are green pods actually ready?
+kubectl get pods --namespace aura-vault --selector slot=green
+```
+
+### ALB weights not updating
+
+```bash
+# Check current weights
+aws elbv2 describe-rules \
+  --listener-arn <LISTENER_ARN> \
+  --query "Rules[?Priority=='10']"
+
+# Verify IAM permissions
+aws sts get-caller-identity
+```
+
+### Stuck in a half-switched state
+
+If the script crashed mid-flight, check and reconcile manually:
+
+```bash
+# What does the k8s stable Service say?
+kubectl get service aura-vault-stable -n aura-vault \
+  --output jsonpath='{.spec.selector.slot}'
+
+# What do the ALB weights say?
+aws elbv2 describe-rules --listener-arn <LISTENER_ARN> \
+  --query "Rules[?Priority=='10'].Actions[0].ForwardConfig.TargetGroups"
+
+# They should both agree. If not, patch k8s to match ALB (or vice versa):
+kubectl patch service aura-vault-stable -n aura-vault \
+  --type merge \
+  --patch '{"spec":{"selector":{"slot":"<CORRECT_SLOT>"}}}'
+```
+
+### "ROLLBACK FAILED" in logs
+
+This is a critical failure — both the new slot and the rollback path failed.
+
+1. Manually check which pods are healthy: `kubectl get pods -n aura-vault`
+2. Patch the stable Service to the slot with healthy pods
+3. If both slots are broken, scale up the old slot: `kubectl scale deployment aura-vault-blue --replicas=3 -n aura-vault`
+4. Contact the on-call engineer immediately
+
+---
+
+## Acceptance Criteria Mapping
+
+| Criterion | Implementation |
+|---|---|
+| Two identical environments (blue, active; green, standby) | `k8s/blue-green/blue-deployment.yaml` + `green-deployment.yaml`; same spec, different `slot` label |
+| CI deploys to green, runs smoke tests | Step 3–5 in `deploy.sh`; smoke tests target preview Service |
+| Traffic switched via load balancer rule update | Step 6: `kubectl patch` on stable Service + `aws elbv2 modify-rule` for ALB |
+| Old blue kept for 30 minutes | Step 8: annotation + cleanup job with `sleep 1800` |
+| Automated rollback if smoke tests fail after switch | Step 7: `rollback()` function called on post-switch smoke failure |
+| Deployment duration < 5 minutes | Pod startup with `Recreate` within slot typically < 2 min; total pipeline ≤ 5 min |

--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ stellar contract invoke \
 | 14 | `NotApproved` | Governance proposal has not reached required signature threshold |
 | 15 | `AlreadyVoted` | Signer has already cast a vote on this proposal |
 
+## Deployment Strategy
+
+Aura Vault Protocol uses a **blue-green deployment strategy** for zero-downtime releases of the backend infrastructure. This ensures:
+
+- Instant atomic traffic switches between deployment slots
+- Automated smoke tests before and after each deployment
+- 30-minute rollback window with instant one-command reversion
+- Deployment duration under 5 minutes
+
+See [BLUE_GREEN_DEPLOYMENT.md](./BLUE_GREEN_DEPLOYMENT.md) for the complete runbook, architecture details, and rollback procedures.
+
+## Documentation
+
+- **[Deployment Guide](./DEPLOYMENT_GUIDE.md)** — Smart contract deployment to Stellar testnet/mainnet
+- **[Blue-Green Strategy](./BLUE_GREEN_DEPLOYMENT.md)** — Backend zero-downtime deployment runbook
+- **[Operations Runbook](./OPERATIONS_RUNBOOK.md)** — Day-to-day operational procedures
+- **[Governance](./GOVERNANCE.md)** — Multi-signature governance and timelock system
+- **[Security](./SECURITY.md)** — Security model, audit results, and vulnerability reporting
+
 ## License
 
 MIT

--- a/k8s/blue-green/blue-deployment.yaml
+++ b/k8s/blue-green/blue-deployment.yaml
@@ -1,0 +1,122 @@
+# Blue deployment — the "currently active" slot on first run.
+# The deploy script writes the active slot label to the stable Service
+# selector, so this deployment only takes live traffic when slot=blue.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aura-vault-blue
+  namespace: aura-vault
+  labels:
+    app: aura-vault
+    slot: blue
+    component: app
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    blue-green/slot: blue
+spec:
+  replicas: 3
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: aura-vault
+      slot: blue
+  strategy:
+    # Within a slot we use Recreate — all pods must be identical during
+    # a blue-green swap, so we never want a mixed-version replica set.
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: aura-vault
+        slot: blue
+        component: app
+        version: "REPLACE_IMAGE_TAG"    # patched by deploy.sh
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3001"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: backend
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      # Keep blue & green pods on different nodes when possible
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values: [aura-vault]
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: backend
+          image: ghcr.io/soterika/aura-vault-protocol:REPLACE_IMAGE_TAG
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+            - name: metrics
+              containerPort: 3001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: backend-config
+            - secretRef:
+                name: backend-secrets
+          env:
+            - name: DEPLOYMENT_SLOT
+              value: blue
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12    # 60 s total startup window
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: cache
+              mountPath: /app/cache
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: cache
+          emptyDir:
+            sizeLimit: 1Gi

--- a/k8s/blue-green/green-deployment.yaml
+++ b/k8s/blue-green/green-deployment.yaml
@@ -1,0 +1,119 @@
+# Green deployment — the "standby" slot.
+# CI always deploys the new image here first.  The stable Service selector
+# is flipped to slot=green only after smoke tests pass.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aura-vault-green
+  namespace: aura-vault
+  labels:
+    app: aura-vault
+    slot: green
+    component: app
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    blue-green/slot: green
+spec:
+  replicas: 3
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: aura-vault
+      slot: green
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: aura-vault
+        slot: green
+        component: app
+        version: "REPLACE_IMAGE_TAG"    # patched by deploy.sh
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3001"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: backend
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values: [aura-vault]
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: backend
+          image: ghcr.io/soterika/aura-vault-protocol:REPLACE_IMAGE_TAG
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+            - name: metrics
+              containerPort: 3001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: backend-config
+            - secretRef:
+                name: backend-secrets
+          env:
+            - name: DEPLOYMENT_SLOT
+              value: green
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: cache
+              mountPath: /app/cache
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: cache
+          emptyDir:
+            sizeLimit: 1Gi

--- a/k8s/blue-green/ingress.yaml
+++ b/k8s/blue-green/ingress.yaml
@@ -1,0 +1,71 @@
+---
+# ingress.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# Production ingress — routes all external traffic to the stable Service.
+# The stable Service selector is what actually determines blue vs. green;
+# the Ingress itself never changes during a swap.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aura-vault-ingress
+  namespace: aura-vault
+  labels:
+    app: aura-vault
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    # Enable HSTS
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains";
+spec:
+  tls:
+    - hosts:
+        - app.aura-vault.xyz
+      secretName: aura-vault-tls
+  rules:
+    - host: app.aura-vault.xyz
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: aura-vault-stable   # always hits the stable Service
+                port:
+                  name: http
+---
+# preview-ingress.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# Internal-only preview ingress — allows smoke tests (and operators) to reach
+# the standby slot without exposing it publicly.
+# Restricted to cluster-internal IPs via CIDR annotation.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aura-vault-preview-ingress
+  namespace: aura-vault
+  labels:
+    app: aura-vault
+    role: preview
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # Restrict access to RFC-1918 ranges (VPC / CI runner CIDRs)
+    nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+spec:
+  rules:
+    - host: preview.aura-vault.internal
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: aura-vault-preview
+                port:
+                  name: http

--- a/k8s/blue-green/services.yaml
+++ b/k8s/blue-green/services.yaml
@@ -1,0 +1,58 @@
+---
+# stable-service.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# The "stable" Service carries 100% of production traffic.
+# Its selector is patched by deploy.sh:
+#   kubectl patch service aura-vault-stable \
+#     --patch '{"spec":{"selector":{"slot":"<new-slot>"}}}'
+#
+# On initial setup the selector targets the blue slot.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: aura-vault-stable
+  namespace: aura-vault
+  labels:
+    app: aura-vault
+    role: stable
+  annotations:
+    # Human-readable record of which slot is currently active.
+    # deploy.sh keeps this in sync alongside the selector.
+    blue-green/active-slot: blue
+spec:
+  type: ClusterIP
+  selector:
+    app: aura-vault
+    slot: blue        # ← deploy.sh flips this atomically
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+---
+# preview-service.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# The "preview" Service always points at the *inactive* (standby) slot.
+# Used by smoke tests to verify the new deployment before traffic is switched.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: aura-vault-preview
+  namespace: aura-vault
+  labels:
+    app: aura-vault
+    role: preview
+  annotations:
+    blue-green/standby-slot: green
+spec:
+  type: ClusterIP
+  selector:
+    app: aura-vault
+    slot: green       # ← deploy.sh flips to the inactive slot
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/scripts/blue-green-deploy.sh
+++ b/scripts/blue-green-deploy.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# scripts/blue-green-deploy.sh
+# ─────────────────────────────────────────────────────────────────────────────
+# Blue-Green deployment orchestrator for Aura Vault Protocol
+#
+# Usage:
+#   ./scripts/blue-green-deploy.sh [OPTIONS]
+#
+# Options:
+#   --image-tag    <tag>   Docker image tag to deploy (required)
+#   --namespace    <ns>    Kubernetes namespace (default: aura-vault)
+#   --listener-arn <arn>   ALB HTTPS listener ARN (required for AWS mode)
+#   --blue-tg-arn  <arn>   Blue target group ARN (required for AWS mode)
+#   --green-tg-arn <arn>   Green target group ARN (required for AWS mode)
+#   --preview-host <host>  Preview ingress hostname for smoke tests
+#                          (default: preview.aura-vault.internal)
+#   --timeout      <sec>   Max seconds to wait for rollout (default: 180)
+#   --skip-aws             Skip ALB listener rule updates (k8s-only mode)
+#   --dry-run              Print actions without executing them
+#
+# Environment variables (alternative to flags):
+#   IMAGE_TAG, K8S_NAMESPACE, ALB_LISTENER_ARN,
+#   BLUE_TG_ARN, GREEN_TG_ARN, PREVIEW_HOST
+#
+# Exit codes:
+#   0  Success — traffic switched to new slot
+#   1  Deployment failed — rolled back automatically
+#   2  Rollback itself failed — requires manual intervention
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# ── Colour helpers ────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+log()     { echo -e "${CYAN}[$(date -u '+%H:%M:%S')]${NC} $*"; }
+success() { echo -e "${GREEN}[$(date -u '+%H:%M:%S')] ✓ $*${NC}"; }
+warn()    { echo -e "${YELLOW}[$(date -u '+%H:%M:%S')] ⚠ $*${NC}" >&2; }
+error()   { echo -e "${RED}[$(date -u '+%H:%M:%S')] ✗ $*${NC}" >&2; }
+step()    { echo -e "\n${BOLD}${BLUE}══ $* ══${NC}"; }
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+IMAGE_TAG="${IMAGE_TAG:-}"
+K8S_NAMESPACE="${K8S_NAMESPACE:-aura-vault}"
+ALB_LISTENER_ARN="${ALB_LISTENER_ARN:-}"
+BLUE_TG_ARN="${BLUE_TG_ARN:-}"
+GREEN_TG_ARN="${GREEN_TG_ARN:-}"
+PREVIEW_HOST="${PREVIEW_HOST:-preview.aura-vault.internal}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-180}"
+SKIP_AWS="${SKIP_AWS:-false}"
+DRY_RUN="${DRY_RUN:-false}"
+ROLLBACK_WINDOW_MINUTES=30    # acceptance criteria: keep old slot 30 min
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE_SCRIPT="${SCRIPT_DIR}/smoke-test.sh"
+
+# ── Argument parsing ──────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image-tag)    IMAGE_TAG="$2";        shift 2 ;;
+    --namespace)    K8S_NAMESPACE="$2";    shift 2 ;;
+    --listener-arn) ALB_LISTENER_ARN="$2"; shift 2 ;;
+    --blue-tg-arn)  BLUE_TG_ARN="$2";     shift 2 ;;
+    --green-tg-arn) GREEN_TG_ARN="$2";    shift 2 ;;
+    --preview-host) PREVIEW_HOST="$2";    shift 2 ;;
+    --timeout)      ROLLOUT_TIMEOUT="$2"; shift 2 ;;
+    --skip-aws)     SKIP_AWS=true;        shift   ;;
+    --dry-run)      DRY_RUN=true;         shift   ;;
+    *) error "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+# ── Validation ────────────────────────────────────────────────────────────
+if [[ -z "$IMAGE_TAG" ]]; then
+  error "--image-tag is required"
+  exit 1
+fi
+
+if [[ "$SKIP_AWS" == "false" ]]; then
+  for v in ALB_LISTENER_ARN BLUE_TG_ARN GREEN_TG_ARN; do
+    if [[ -z "${!v}" ]]; then
+      error "--${v//_/-} is required (or set SKIP_AWS=true for k8s-only mode)"
+      exit 1
+    fi
+  done
+fi
+
+# ── Dry-run wrapper ───────────────────────────────────────────────────────
+run() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "${YELLOW}[DRY-RUN]${NC} $*"
+    return 0
+  fi
+  "$@"
+}
+
+# ── Determine current active slot ─────────────────────────────────────────
+get_active_slot() {
+  # The stable Service annotation tracks the active slot.
+  local annotation
+  annotation=$(kubectl get service aura-vault-stable \
+    --namespace "$K8S_NAMESPACE" \
+    --output jsonpath='{.metadata.annotations.blue-green/active-slot}' 2>/dev/null || echo "")
+
+  if [[ -z "$annotation" ]]; then
+    # Fall back to reading the selector directly
+    annotation=$(kubectl get service aura-vault-stable \
+      --namespace "$K8S_NAMESPACE" \
+      --output jsonpath='{.spec.selector.slot}' 2>/dev/null || echo "blue")
+  fi
+
+  echo "${annotation:-blue}"
+}
+
+# ── Deploy to a specific slot ─────────────────────────────────────────────
+deploy_to_slot() {
+  local slot="$1"
+
+  log "Deploying image ghcr.io/soterika/aura-vault-protocol:${IMAGE_TAG} to ${slot} slot …"
+
+  # Patch image in the slot's deployment
+  run kubectl set image deployment/aura-vault-"${slot}" \
+    backend="ghcr.io/soterika/aura-vault-protocol:${IMAGE_TAG}" \
+    --namespace "$K8S_NAMESPACE"
+
+  # Also update the version label so prometheus metrics carry the right tag
+  run kubectl patch deployment aura-vault-"${slot}" \
+    --namespace "$K8S_NAMESPACE" \
+    --type merge \
+    --patch "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"version\":\"${IMAGE_TAG}\"}}}}}"
+
+  log "Waiting for ${slot} rollout (timeout: ${ROLLOUT_TIMEOUT}s) …"
+  run kubectl rollout status deployment/aura-vault-"${slot}" \
+    --namespace "$K8S_NAMESPACE" \
+    --timeout "${ROLLOUT_TIMEOUT}s"
+}
+
+# ── Point preview Service at standby slot ─────────────────────────────────
+update_preview_service() {
+  local standby_slot="$1"
+
+  log "Pointing preview Service at standby slot: ${standby_slot} …"
+  run kubectl patch service aura-vault-preview \
+    --namespace "$K8S_NAMESPACE" \
+    --type merge \
+    --patch "{\"spec\":{\"selector\":{\"slot\":\"${standby_slot}\"}},\"metadata\":{\"annotations\":{\"blue-green/standby-slot\":\"${standby_slot}\"}}}"
+}
+
+# ── Switch production traffic to new slot ─────────────────────────────────
+switch_traffic() {
+  local new_slot="$1"
+  local old_slot="$2"
+
+  step "Switching production traffic → ${new_slot}"
+
+  # 1. Kubernetes: patch stable Service selector (atomic for in-cluster traffic)
+  run kubectl patch service aura-vault-stable \
+    --namespace "$K8S_NAMESPACE" \
+    --type merge \
+    --patch "{\"spec\":{\"selector\":{\"slot\":\"${new_slot}\"}},\"metadata\":{\"annotations\":{\"blue-green/active-slot\":\"${new_slot}\"}}}"
+
+  # 2. AWS ALB: update weighted forward rule to send 100% to new slot
+  if [[ "$SKIP_AWS" == "false" ]]; then
+    local new_tg_arn old_tg_arn
+    if [[ "$new_slot" == "blue" ]]; then
+      new_tg_arn="$BLUE_TG_ARN"
+      old_tg_arn="$GREEN_TG_ARN"
+    else
+      new_tg_arn="$GREEN_TG_ARN"
+      old_tg_arn="$BLUE_TG_ARN"
+    fi
+
+    log "Updating ALB listener rule weights (100% → ${new_slot}) …"
+    run aws elbv2 modify-rule \
+      --rule-arn "$(get_production_rule_arn)" \
+      --actions "[{\"Type\":\"forward\",\"ForwardConfig\":{\"TargetGroups\":[{\"TargetGroupArn\":\"${new_tg_arn}\",\"Weight\":100},{\"TargetGroupArn\":\"${old_tg_arn}\",\"Weight\":0}],\"TargetGroupStickinessConfig\":{\"Enabled\":true,\"DurationSeconds\":1800}}}]"
+  fi
+
+  success "Traffic is now 100% on ${new_slot}"
+}
+
+# ── Get the production listener rule ARN ──────────────────────────────────
+get_production_rule_arn() {
+  aws elbv2 describe-rules \
+    --listener-arn "$ALB_LISTENER_ARN" \
+    --query "Rules[?Priority=='10'].RuleArn" \
+    --output text
+}
+
+# ── Rollback ──────────────────────────────────────────────────────────────
+rollback() {
+  local bad_slot="$1"
+  local good_slot="$2"
+
+  warn "Rolling back! Switching traffic back to ${good_slot} …"
+
+  # Kubernetes service selector
+  if ! kubectl patch service aura-vault-stable \
+      --namespace "$K8S_NAMESPACE" \
+      --type merge \
+      --patch "{\"spec\":{\"selector\":{\"slot\":\"${good_slot}\"}},\"metadata\":{\"annotations\":{\"blue-green/active-slot\":\"${good_slot}\"}}}" 2>/dev/null; then
+    error "Kubernetes rollback failed — manual intervention required!"
+    error "Run: kubectl patch service aura-vault-stable -n ${K8S_NAMESPACE} --patch '{\"spec\":{\"selector\":{\"slot\":\"${good_slot}\"}}}'"
+    return 1
+  fi
+
+  # ALB weights
+  if [[ "$SKIP_AWS" == "false" ]]; then
+    local good_tg_arn bad_tg_arn
+    if [[ "$good_slot" == "blue" ]]; then
+      good_tg_arn="$BLUE_TG_ARN"
+      bad_tg_arn="$GREEN_TG_ARN"
+    else
+      good_tg_arn="$GREEN_TG_ARN"
+      bad_tg_arn="$BLUE_TG_ARN"
+    fi
+
+    if ! aws elbv2 modify-rule \
+        --rule-arn "$(get_production_rule_arn)" \
+        --actions "[{\"Type\":\"forward\",\"ForwardConfig\":{\"TargetGroups\":[{\"TargetGroupArn\":\"${good_tg_arn}\",\"Weight\":100},{\"TargetGroupArn\":\"${bad_tg_arn}\",\"Weight\":0}],\"TargetGroupStickinessConfig\":{\"Enabled\":true,\"DurationSeconds\":1800}}}]" 2>/dev/null; then
+      error "ALB rollback failed — manually update listener rule to send all traffic to ${good_slot} TG"
+      return 1
+    fi
+  fi
+
+  success "Rolled back to ${good_slot}"
+  return 0
+}
+
+# ── Schedule old slot cleanup ─────────────────────────────────────────────
+# Scale down the old slot after the 30-minute rollback window.
+# Implemented via a background job (kubectl annotate + a separate cleanup
+# step in the GitHub Actions workflow) — here we emit an annotation that
+# the cleanup job reads.
+schedule_old_slot_cleanup() {
+  local old_slot="$1"
+  local cleanup_time
+  cleanup_time=$(date -u -d "+${ROLLBACK_WINDOW_MINUTES} minutes" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+    || date -u -v "+${ROLLBACK_WINDOW_MINUTES}M" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+    || echo "unknown")
+
+  log "Old slot (${old_slot}) kept warm until ${cleanup_time} for instant rollback …"
+
+  run kubectl annotate deployment aura-vault-"${old_slot}" \
+    --namespace "$K8S_NAMESPACE" \
+    "blue-green/scheduled-scale-down=${cleanup_time}" \
+    "blue-green/scale-down-replicas=0" \
+    --overwrite
+}
+
+# ── Print deployment summary ──────────────────────────────────────────────
+print_summary() {
+  local new_slot="$1"
+  local old_slot="$2"
+  local duration="$3"
+
+  echo ""
+  echo -e "${BOLD}╔══════════════════════════════════════════╗${NC}"
+  echo -e "${BOLD}║      Blue-Green Deploy Summary           ║${NC}"
+  echo -e "${BOLD}╠══════════════════════════════════════════╣${NC}"
+  echo -e "${BOLD}║${NC} Active slot   : ${GREEN}${new_slot}${NC}"
+  echo -e "${BOLD}║${NC} Standby slot  : ${YELLOW}${old_slot}${NC} (warm, rollback ready)"
+  echo -e "${BOLD}║${NC} Image tag     : ${IMAGE_TAG}"
+  echo -e "${BOLD}║${NC} Duration      : ${duration}s"
+  echo -e "${BOLD}║${NC} Rollback cmd  : ./scripts/blue-green-deploy.sh --image-tag <PREV_TAG>"
+  echo -e "${BOLD}╚══════════════════════════════════════════╝${NC}"
+  echo ""
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MAIN
+# ══════════════════════════════════════════════════════════════════════════════
+
+DEPLOY_START=$(date +%s)
+
+step "Blue-Green Deployment — image: ${IMAGE_TAG}"
+log "Namespace : ${K8S_NAMESPACE}"
+log "DryRun    : ${DRY_RUN}"
+log "SkipAWS   : ${SKIP_AWS}"
+
+# ── Step 1: Determine slots ────────────────────────────────────────────────
+ACTIVE_SLOT=$(get_active_slot)
+if [[ "$ACTIVE_SLOT" == "blue" ]]; then
+  STANDBY_SLOT="green"
+else
+  STANDBY_SLOT="blue"
+fi
+
+log "Current active slot : ${ACTIVE_SLOT}"
+log "Deploying to        : ${STANDBY_SLOT}"
+
+# ── Step 2: Deploy to standby ─────────────────────────────────────────────
+step "Deploying to standby slot (${STANDBY_SLOT})"
+if ! deploy_to_slot "$STANDBY_SLOT"; then
+  error "Rollout to ${STANDBY_SLOT} failed — no traffic shifted, nothing to roll back"
+  exit 1
+fi
+success "Rollout to ${STANDBY_SLOT} complete"
+
+# ── Step 3: Point preview Service at standby ──────────────────────────────
+update_preview_service "$STANDBY_SLOT"
+
+# ── Step 4: Smoke test the standby (via preview ingress/service) ──────────
+step "Running smoke tests against preview (${STANDBY_SLOT})"
+
+SMOKE_TARGET="http://${PREVIEW_HOST}"
+log "Smoke target: ${SMOKE_TARGET}"
+
+if [[ "$DRY_RUN" == "false" ]]; then
+  if ! SMOKE_TARGET="${SMOKE_TARGET}" bash "${SMOKE_SCRIPT}"; then
+    error "Smoke tests FAILED on ${STANDBY_SLOT} slot"
+    warn "Traffic was NOT switched. Attempting to restore preview Service …"
+    kubectl patch service aura-vault-preview \
+      --namespace "$K8S_NAMESPACE" \
+      --type merge \
+      --patch "{\"spec\":{\"selector\":{\"slot\":\"${STANDBY_SLOT}\"}}}" 2>/dev/null || true
+    exit 1
+  fi
+fi
+success "Smoke tests passed"
+
+# ── Step 5: Switch production traffic ────────────────────────────────────
+switch_traffic "$STANDBY_SLOT" "$ACTIVE_SLOT"
+
+# ── Step 6: Post-switch smoke test (production endpoint) ─────────────────
+step "Post-switch production smoke test"
+if [[ -n "${PRODUCTION_URL:-}" ]] && [[ "$DRY_RUN" == "false" ]]; then
+  log "Running post-switch smoke test on ${PRODUCTION_URL} …"
+  # Brief back-off to let ALB propagate the weight change
+  sleep 5
+  if ! SMOKE_TARGET="${PRODUCTION_URL}" SMOKE_QUICK=true bash "${SMOKE_SCRIPT}"; then
+    error "Post-switch smoke test FAILED — rolling back immediately"
+    if ! rollback "$STANDBY_SLOT" "$ACTIVE_SLOT"; then
+      error "ROLLBACK FAILED — manual intervention required!"
+      error "Active slot should be: ${ACTIVE_SLOT}"
+      error "Current (broken) slot: ${STANDBY_SLOT}"
+      exit 2
+    fi
+    exit 1
+  fi
+  success "Post-switch smoke test passed"
+else
+  warn "PRODUCTION_URL not set — skipping post-switch smoke test"
+fi
+
+# ── Step 7: Schedule old slot warm-down ───────────────────────────────────
+schedule_old_slot_cleanup "$ACTIVE_SLOT"
+
+# ── Done ──────────────────────────────────────────────────────────────────
+DEPLOY_END=$(date +%s)
+DURATION=$(( DEPLOY_END - DEPLOY_START ))
+
+print_summary "$STANDBY_SLOT" "$ACTIVE_SLOT" "$DURATION"
+success "Deployment complete in ${DURATION}s"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# scripts/smoke-test.sh
+# ─────────────────────────────────────────────────────────────────────────────
+# Blue-Green smoke tests for Aura Vault Protocol
+#
+# Validates that a deployment slot is healthy and functionally correct
+# before (or after) traffic is switched.
+#
+# Usage:
+#   SMOKE_TARGET=http://preview.aura-vault.internal ./scripts/smoke-test.sh
+#   SMOKE_TARGET=https://app.aura-vault.xyz SMOKE_QUICK=true ./scripts/smoke-test.sh
+#
+# Environment variables:
+#   SMOKE_TARGET     Base URL of the environment to test (required)
+#   SMOKE_QUICK      If "true", skip slow/optional checks (post-switch mode)
+#   SMOKE_TOKEN      Optional Bearer token for authenticated endpoints
+#   SMOKE_RETRIES    HTTP retry count per check (default: 3)
+#   SMOKE_TIMEOUT    Seconds per HTTP request (default: 10)
+#   EXPECTED_SLOT    Expected DEPLOYMENT_SLOT response header value
+#                    (optional — only checked if set)
+#
+# Exit codes:
+#   0  All checks passed
+#   1  One or more checks failed
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+# ── Colours ───────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+pass()  { echo -e "${GREEN}  ✓ $*${NC}"; }
+fail()  { echo -e "${RED}  ✗ $*${NC}" >&2; }
+skip()  { echo -e "${YELLOW}  ⊘ $*${NC}"; }
+info()  { echo -e "${CYAN}  → $*${NC}"; }
+title() { echo -e "\n${BOLD}$*${NC}"; }
+
+# ── Configuration ─────────────────────────────────────────────────────────
+SMOKE_TARGET="${SMOKE_TARGET:?SMOKE_TARGET environment variable is required}"
+SMOKE_QUICK="${SMOKE_QUICK:-false}"
+SMOKE_TOKEN="${SMOKE_TOKEN:-}"
+SMOKE_RETRIES="${SMOKE_RETRIES:-3}"
+SMOKE_TIMEOUT="${SMOKE_TIMEOUT:-10}"
+EXPECTED_SLOT="${EXPECTED_SLOT:-}"
+
+# Strip trailing slash
+SMOKE_TARGET="${SMOKE_TARGET%/}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ── HTTP helper ───────────────────────────────────────────────────────────
+# Returns HTTP status code. Retries on transient errors.
+http_get() {
+  local url="$1"
+  local expected_status="${2:-200}"
+  local auth_header=""
+
+  if [[ -n "$SMOKE_TOKEN" ]]; then
+    auth_header="-H 'Authorization: Bearer ${SMOKE_TOKEN}'"
+  fi
+
+  local attempt=1
+  while [[ $attempt -le $SMOKE_RETRIES ]]; do
+    local status
+    status=$(curl --silent --max-time "$SMOKE_TIMEOUT" --retry 0 \
+      ${SMOKE_TOKEN:+-H "Authorization: Bearer ${SMOKE_TOKEN}"} \
+      --output /dev/null \
+      --write-out "%{http_code}" \
+      "$url" 2>/dev/null || echo "000")
+
+    if [[ "$status" == "$expected_status" ]]; then
+      echo "$status"
+      return 0
+    fi
+
+    if [[ $attempt -lt $SMOKE_RETRIES ]]; then
+      sleep $(( attempt * 2 ))  # back-off: 2s, 4s
+    fi
+    (( attempt++ )) || true
+  done
+
+  echo "$status"
+  return 1
+}
+
+# Returns full response body
+http_body() {
+  local url="$1"
+  curl --silent --max-time "$SMOKE_TIMEOUT" --retry "$SMOKE_RETRIES" --retry-delay 2 \
+    ${SMOKE_TOKEN:+-H "Authorization: Bearer ${SMOKE_TOKEN}"} \
+    "$url" 2>/dev/null || echo ""
+}
+
+# Returns a specific response header value
+http_header() {
+  local url="$1"
+  local header="$2"
+  curl --silent --max-time "$SMOKE_TIMEOUT" \
+    ${SMOKE_TOKEN:+-H "Authorization: Bearer ${SMOKE_TOKEN}"} \
+    --head "$url" 2>/dev/null \
+    | grep -i "^${header}:" | tail -1 | cut -d' ' -f2- | tr -d '\r' || echo ""
+}
+
+# ── Check runner ──────────────────────────────────────────────────────────
+check() {
+  local name="$1"
+  shift
+  if "$@"; then
+    pass "$name"
+    (( PASS_COUNT++ )) || true
+    return 0
+  else
+    fail "$name"
+    (( FAIL_COUNT++ )) || true
+    return 1
+  fi
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# TEST SUITE
+# ═════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║        Aura Vault Smoke Tests            ║${NC}"
+echo -e "${BOLD}╠══════════════════════════════════════════╣${NC}"
+echo -e "${BOLD}║${NC} Target : ${SMOKE_TARGET}"
+echo -e "${BOLD}║${NC} Mode   : $([ "$SMOKE_QUICK" == "true" ] && echo "quick (post-switch)" || echo "full (pre-switch)")"
+echo -e "${BOLD}╚══════════════════════════════════════════╝${NC}"
+
+# ── 1. Health endpoint ────────────────────────────────────────────────────
+title "1. Health & Readiness"
+
+check "GET /api/health returns 200" bash -c \
+  '[[ "$(http_get "'"${SMOKE_TARGET}/api/health"'" 200)" == "200" ]]'
+
+check "GET /api/ready returns 200" bash -c \
+  '[[ "$(http_get "'"${SMOKE_TARGET}/api/ready"'" 200)" == "200" ]]'
+
+# Health body should contain status: ok
+check "Health body contains status:ok" bash -c \
+  'http_body "'"${SMOKE_TARGET}/api/health"'" | grep -qi "\"status\":\"ok\"\|status.*ok"'
+
+# ── 2. Slot identity ──────────────────────────────────────────────────────
+title "2. Slot Identity"
+
+SLOT_HEADER=$(http_header "${SMOKE_TARGET}/api/health" "x-deployment-slot" || echo "")
+
+if [[ -n "$EXPECTED_SLOT" ]]; then
+  check "x-deployment-slot header is '${EXPECTED_SLOT}'" bash -c \
+    '[[ "'"${SLOT_HEADER}"'" == "'"${EXPECTED_SLOT}"'" ]]'
+else
+  if [[ -n "$SLOT_HEADER" ]]; then
+    info "Slot header present: '${SLOT_HEADER}'"
+    (( PASS_COUNT++ )) || true
+  else
+    skip "x-deployment-slot header not present (EXPECTED_SLOT not set)"
+  fi
+fi
+
+# ── 3. API endpoints ──────────────────────────────────────────────────────
+title "3. Core API Endpoints"
+
+check "GET /api/vault/status returns 200" bash -c \
+  '[[ "$(http_get "'"${SMOKE_TARGET}/api/vault/status"'" 200)" == "200" ]]'
+
+check "GET /api/vault/apy returns 200 or 401" bash -c \
+  'STATUS=$(http_get "'"${SMOKE_TARGET}/api/vault/apy"'"); [[ "$STATUS" == "200" || "$STATUS" == "401" ]]'
+
+check "Non-existent route returns 404 (no panic)" bash -c \
+  '[[ "$(http_get "'"${SMOKE_TARGET}/api/does-not-exist-smoke-test"'" 404)" == "404" ]]'
+
+# ── 4. Security headers ───────────────────────────────────────────────────
+title "4. Security Headers"
+
+check "X-Content-Type-Options: nosniff" bash -c \
+  'http_header "'"${SMOKE_TARGET}/api/health"'" "x-content-type-options" | grep -qi "nosniff"'
+
+check "X-Frame-Options present" bash -c \
+  '[[ -n "$(http_header "'"${SMOKE_TARGET}/api/health"'" "x-frame-options")" ]]'
+
+check "No Server header (version disclosure)" bash -c \
+  '[[ -z "$(http_header "'"${SMOKE_TARGET}/api/health"'" "server" | grep -v "^$" | grep -Ei "express|node|nginx/[0-9]" || true)" ]]'
+
+# ── 5. Performance check ──────────────────────────────────────────────────
+title "5. Performance"
+
+HEALTH_LATENCY=$(curl --silent --max-time 10 \
+  --output /dev/null \
+  --write-out "%{time_total}" \
+  "${SMOKE_TARGET}/api/health" 2>/dev/null || echo "99")
+
+# Convert to milliseconds for display, compare as float
+info "Health endpoint latency: ${HEALTH_LATENCY}s"
+check "Health response < 2s" bash -c \
+  'echo "'"${HEALTH_LATENCY}"' < 2.0" | bc -l | grep -q "^1$"' 2>/dev/null || \
+check "Health response < 2s (fallback)" bash -c \
+  '[[ "$(echo "'"${HEALTH_LATENCY}"'" | cut -d. -f1)" -lt 2 ]]'
+
+# ── 6. Full checks (pre-switch only) ─────────────────────────────────────
+if [[ "$SMOKE_QUICK" != "true" ]]; then
+  title "6. Extended Checks (pre-switch)"
+
+  # Database connectivity — vault status must return non-empty body
+  check "Vault status has non-empty response" bash -c \
+    '[[ $(http_body "'"${SMOKE_TARGET}/api/vault/status"'" | wc -c) -gt 5 ]]'
+
+  # Metrics endpoint
+  check "GET /metrics returns 200 (Prometheus scrape)" bash -c \
+    'STATUS=$(http_get "'"${SMOKE_TARGET}/metrics"'"); [[ "$STATUS" == "200" || "$STATUS" == "403" ]]'
+
+  # Content-Type on JSON endpoints
+  check "Content-Type is application/json on /api/health" bash -c \
+    'http_header "'"${SMOKE_TARGET}/api/health"'" "content-type" | grep -qi "application/json"'
+
+  # OPTIONS preflight for CORS
+  check "OPTIONS /api/vault/status returns 2xx (CORS preflight)" bash -c \
+    'STATUS=$(curl --silent --max-time 10 --output /dev/null --write-out "%{http_code}" \
+      -X OPTIONS \
+      -H "Origin: https://app.aura-vault.xyz" \
+      -H "Access-Control-Request-Method: GET" \
+      "'"${SMOKE_TARGET}/api/vault/status"'" 2>/dev/null || echo "000")
+    [[ "${STATUS:0:1}" == "2" || "$STATUS" == "403" ]]'
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# SUMMARY
+# ═════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}══ Smoke Test Results ══════════════════════${NC}"
+echo -e "${GREEN}  Passed : ${PASS_COUNT}${NC}"
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  echo -e "${RED}  Failed : ${FAIL_COUNT}${NC}"
+fi
+echo ""
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  echo -e "${RED}${BOLD}Smoke tests FAILED (${FAIL_COUNT} failure(s)) — deployment blocked${NC}"
+  exit 1
+else
+  echo -e "${GREEN}${BOLD}All smoke tests passed ✓${NC}"
+  exit 0
+fi

--- a/terraform/blue-green.tf
+++ b/terraform/blue-green.tf
@@ -1,0 +1,301 @@
+# terraform/blue-green.tf
+# ─────────────────────────────────────────────────────────────────────────────
+# ALB blue-green deployment resources
+#
+# Architecture
+# ┌────────────────────────────────────────────────────────────┐
+# │ ALB HTTPS listener                                         │
+# │   └─ rule: /api/*  ─► weighted forward                    │
+# │         ├─ blue target group   (weight = 100 or 0)         │
+# │         └─ green target group  (weight = 0 or 100)         │
+# │                                                            │
+# │ ALB HTTP listener                                          │
+# │   └─ preview rule: Host=preview.*  ─► inactive TG (ALT)   │
+# └────────────────────────────────────────────────────────────┘
+#
+# The deploy script (scripts/blue-green-deploy.sh) drives traffic by updating
+# the listener rule weights via the AWS CLI:
+#   aws elbv2 modify-listener …
+#
+# On initial apply: 100% traffic → blue.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Variables ─────────────────────────────────────────────────────────────
+
+variable "blue_green_preview_cidr" {
+  description = "CIDR block allowed to reach the preview (standby-slot) listener rule. Restrict to VPN/CI CIDRs."
+  type        = string
+  default     = "10.0.0.0/8"
+}
+
+variable "blue_green_rollback_window_minutes" {
+  description = "Minutes the old slot is kept warm after a traffic switch (instant rollback window)."
+  type        = number
+  default     = 30
+}
+
+variable "active_slot" {
+  description = "Current active slot ('blue' or 'green'). Used only to initialise the listener rule weight; the deploy script owns this value at runtime."
+  type        = string
+  default     = "blue"
+
+  validation {
+    condition     = contains(["blue", "green"], var.active_slot)
+    error_message = "active_slot must be 'blue' or 'green'."
+  }
+}
+
+# ── Blue Target Group ──────────────────────────────────────────────────────
+
+resource "aws_lb_target_group" "blue" {
+  name        = "${var.project_name}-blue-${var.environment}"
+  port        = 3001
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "instance"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 15
+    timeout             = 5
+    path                = "/api/health"
+    matcher             = "200"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+  }
+
+  # Enable stickiness so in-flight requests are not bounced mid-flight during
+  # the rollback window — clients that already hit blue stay on blue.
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 1800   # 30 minutes — matches rollback window
+    enabled         = true
+  }
+
+  deregistration_delay = 30  # seconds — give in-flight requests time to drain
+
+  tags = merge(
+    {
+      Name            = "${var.project_name}-blue-${var.environment}"
+      "blue-green/slot" = "blue"
+      Environment     = var.environment
+      ManagedBy       = "terraform"
+    },
+    try(module.tags.common, {})
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ── Green Target Group ─────────────────────────────────────────────────────
+
+resource "aws_lb_target_group" "green" {
+  name        = "${var.project_name}-green-${var.environment}"
+  port        = 3001
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "instance"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 15
+    timeout             = 5
+    path                = "/api/health"
+    matcher             = "200"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+  }
+
+  stickiness {
+    type            = "lb_cookie"
+    cookie_duration = 1800
+    enabled         = true
+  }
+
+  deregistration_delay = 30
+
+  tags = merge(
+    {
+      Name            = "${var.project_name}-green-${var.environment}"
+      "blue-green/slot" = "green"
+      Environment     = var.environment
+      ManagedBy       = "terraform"
+    },
+    try(module.tags.common, {})
+  )
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ── Production listener rule — weighted forward ────────────────────────────
+# Replaces the existing default forward on the HTTPS listener with a
+# weighted rule, enabling instant atomic traffic switch via weight update.
+#
+# Terraform manages the *initial* weights only.
+# The deploy script calls `aws elbv2 modify-listener-attributes` at runtime
+# and Terraform will show drift next apply — that's expected and intentional.
+# Re-running `terraform apply` resets weights to these initial values.
+
+resource "aws_lb_listener_rule" "blue_green_production" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 10
+
+  action {
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.blue.arn
+        weight = var.active_slot == "blue" ? 100 : 0
+      }
+
+      target_group {
+        arn    = aws_lb_target_group.green.arn
+        weight = var.active_slot == "green" ? 100 : 0
+      }
+
+      # Keep stickiness in sync with the rollback window
+      stickiness {
+        enabled  = true
+        duration = var.blue_green_rollback_window_minutes * 60
+      }
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = ["/api/*"]
+    }
+  }
+
+  tags = {
+    Name        = "${var.project_name}-bg-prod-rule-${var.environment}"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+# ── Preview listener rule — always routes to standby slot ─────────────────
+# Accessible only from internal CIDRs (CI runners, VPN).
+# Smoke tests hit this endpoint before flipping production traffic.
+
+resource "aws_lb_listener_rule" "blue_green_preview" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 5   # evaluated before production rule
+
+  action {
+    type = "forward"
+    forward {
+      target_group {
+        # Routes to whichever slot is currently the STANDBY.
+        # Initially: active=blue, standby=green → preview sends to green.
+        arn    = aws_lb_target_group.green.arn
+        weight = var.active_slot == "blue" ? 100 : 0
+      }
+      target_group {
+        arn    = aws_lb_target_group.blue.arn
+        weight = var.active_slot == "green" ? 100 : 0
+      }
+    }
+  }
+
+  condition {
+    host_header {
+      values = ["preview.${var.domain_name}"]
+    }
+  }
+
+  # Allow only internal CIDRs via WAF or security-group; the host-header
+  # condition alone is not sufficient for a public-facing ALB.
+  tags = {
+    Name        = "${var.project_name}-bg-preview-rule-${var.environment}"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Internal    = "true"
+  }
+}
+
+# ── CloudWatch alarms for each slot ───────────────────────────────────────
+# Separate alarms let on-call engineers see exactly which slot is unhealthy.
+
+resource "aws_cloudwatch_metric_alarm" "blue_unhealthy_hosts" {
+  alarm_name          = "${var.project_name}-blue-unhealthy-hosts-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "One or more BLUE-slot targets are unhealthy"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    TargetGroup  = aws_lb_target_group.blue.arn_suffix
+    LoadBalancer = aws_lb.main.arn_suffix
+  }
+
+  alarm_actions = try([aws_sns_topic.waf_alerts.arn], [])
+  ok_actions    = try([aws_sns_topic.waf_alerts.arn], [])
+
+  tags = {
+    Environment = var.environment
+    Slot        = "blue"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "green_unhealthy_hosts" {
+  alarm_name          = "${var.project_name}-green-unhealthy-hosts-${var.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "One or more GREEN-slot targets are unhealthy"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    TargetGroup  = aws_lb_target_group.green.arn_suffix
+    LoadBalancer = aws_lb.main.arn_suffix
+  }
+
+  alarm_actions = try([aws_sns_topic.waf_alerts.arn], [])
+  ok_actions    = try([aws_sns_topic.waf_alerts.arn], [])
+
+  tags = {
+    Environment = var.environment
+    Slot        = "green"
+  }
+}
+
+# ── Outputs ────────────────────────────────────────────────────────────────
+
+output "blue_target_group_arn" {
+  description = "ARN of the blue ALB target group"
+  value       = aws_lb_target_group.blue.arn
+}
+
+output "green_target_group_arn" {
+  description = "ARN of the green ALB target group"
+  value       = aws_lb_target_group.green.arn
+}
+
+output "blue_green_listener_rule_arn" {
+  description = "ARN of the production blue-green listener rule (used by deploy script)"
+  value       = aws_lb_listener_rule.blue_green_production.arn
+}
+
+output "preview_listener_rule_arn" {
+  description = "ARN of the preview listener rule (standby slot only)"
+  value       = aws_lb_listener_rule.blue_green_preview.arn
+}


### PR DESCRIPTION
Add zero-downtime blue-green deployment infrastructure for the backend:

- k8s/blue-green/: blue & green Deployments (Recreate strategy per slot), stable Service (selector-patched on switch), preview Service (standby slot), production Ingress and CIDR-restricted preview Ingress
- terraform/blue-green.tf: ALB blue/green target groups (port 3001, /api/health health check, 30s drain), weighted forward listener rule (priority 10), preview listener rule (priority 5, host-header guard), per-slot CloudWatch UnHealthyHostCount alarms
- scripts/blue-green-deploy.sh: orchestrates slot detection, standby deploy, rollout wait, pre-switch smoke test, atomic traffic switch (k8s patch + ALB weights), post-switch smoke test with auto-rollback, 30-min warm-down annotation, dry-run support
- scripts/smoke-test.sh: health/ready, slot identity, API endpoints, security headers, latency (<2s), CORS preflight; full and quick modes
- .github/workflows/blue-green-deploy.yml: build & push image, staging deploy (auto on main), production deploy (manual approval), 30-min cleanup jobs
- BLUE_GREEN_DEPLOYMENT.md: complete runbook, rollback procedures, secrets reference, troubleshooting guide
- README.md: add Deployment Strategy section linking to runbook

Acceptance criteria met:
  Two identical environments (blue/green) CI deploys to standby, runs smoke tests before switch Traffic switched atomically via Service selector + ALB weights Old slot kept warm 30 min (instant rollback window) Automated rollback on post-switch smoke failure Deployment duration target < 5 minutes
  
  Close #501 