### PR TITLE
feat(backend): DB query performance monitoring with slow query log (#…

### DIFF
--- a/backend/src/routes/vaultRoutes.ts
+++ b/backend/src/routes/vaultRoutes.ts
@@ -11,6 +11,7 @@
 import { Router, Request, Response } from "express";
 import { cacheGet, cacheSet, cacheDel } from "../cache.js";
 import { getVaultStats, VaultStatsData } from "../services/vaultStatsService.js";
+import { getDbMetrics, getSlowQueryLog, dbMetricsPrometheusText } from "../services/dbMonitor.js";
 
 export const VAULT_STATS_CACHE_NS = "vault:stats";
 export const VAULT_STATS_CACHE_KEY = "current";
@@ -102,3 +103,50 @@ vaultRouter.post("/stats/invalidate", async (_req: Request, res: Response): Prom
 export async function invalidateVaultStatsCache(): Promise<void> {
   await cacheDel(VAULT_STATS_CACHE_NS, VAULT_STATS_CACHE_KEY);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #324 — DB Query Performance Monitoring
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/vault/metrics/db
+ * Returns histogram metrics and p99 estimate for each query type.
+ */
+vaultRouter.get("/metrics/db", async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const metrics = await getDbMetrics();
+    res.json({ metrics, generated_at: new Date().toISOString() });
+  } catch (err) {
+    console.error("[vault/metrics/db]", err);
+    res.status(500).json({ error: "Failed to retrieve DB metrics" });
+  }
+});
+
+/**
+ * GET /api/v1/vault/metrics/db/slow-log
+ * Returns the slow query log (most recent first).
+ */
+vaultRouter.get("/metrics/db/slow-log", async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const log = await getSlowQueryLog();
+    res.json({ slow_queries: log, count: log.length, generated_at: new Date().toISOString() });
+  } catch (err) {
+    console.error("[vault/metrics/db/slow-log]", err);
+    res.status(500).json({ error: "Failed to retrieve slow query log" });
+  }
+});
+
+/**
+ * GET /api/v1/vault/metrics/db/prometheus
+ * Returns Prometheus text exposition for db_query_duration_seconds histogram.
+ * Allows Prometheus to scrape this path directly if configured.
+ */
+vaultRouter.get("/metrics/db/prometheus", async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const text = await dbMetricsPrometheusText();
+    res.set("Content-Type", "text/plain; version=0.0.4").send(text);
+  } catch (err) {
+    console.error("[vault/metrics/db/prometheus]", err);
+    res.status(500).send("# error generating metrics\n");
+  }
+});

--- a/backend/src/services/dbMonitor.ts
+++ b/backend/src/services/dbMonitor.ts
@@ -1,0 +1,354 @@
+/**
+ * Database Query Performance Monitoring — Issue #324
+ *
+ * Wraps pg.Pool.query to:
+ *   1. Log queries exceeding SLOW_QUERY_THRESHOLD_MS at WARN level with full SQL + params
+ *   2. Capture EXPLAIN ANALYZE for the slowest queries (above EXPLAIN_THRESHOLD_MS)
+ *   3. Record a Prometheus-compatible histogram in Redis: db_query_duration_seconds
+ *   4. Expose metrics via /api/metrics/db for Grafana dashboard consumption
+ *
+ * Usage:
+ *   import { instrumentedQuery } from './dbMonitor.js';
+ *   const rows = await instrumentedQuery(pool, 'SELECT ...', [params], 'list_positions');
+ *
+ * Or wrap an entire pool:
+ *   const pool = wrapPool(getWritePool(), 'write');
+ */
+
+import pg from "pg";
+import { logger } from "../logger.js";
+import { cacheGet, cacheSet } from "../cache.js";
+
+// ── Thresholds ────────────────────────────────────────────────────────────────
+
+/** Queries slower than this are logged at WARN level. */
+export const SLOW_QUERY_THRESHOLD_MS =
+  parseInt(process.env.SLOW_QUERY_THRESHOLD_MS ?? "100", 10);
+
+/** Queries slower than this also get EXPLAIN ANALYZE captured. */
+export const EXPLAIN_THRESHOLD_MS =
+  parseInt(process.env.EXPLAIN_THRESHOLD_MS ?? "500", 10);
+
+/** Max number of slow query log entries kept in Redis. */
+const SLOW_LOG_MAX_ENTRIES = 200;
+
+/** TTL for slow query log in Redis (seconds). */
+const SLOW_LOG_TTL = 7 * 24 * 3600; // 7 days
+
+// ── Histogram configuration ───────────────────────────────────────────────────
+
+/** Bucket upper bounds in seconds for the Prometheus histogram. */
+const HISTOGRAM_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+
+const METRICS_NS = "metrics:db";
+const HISTOGRAM_KEY = "query_duration_histogram";
+const SLOW_LOG_KEY = "slow_query_log";
+const METRICS_TTL = 86400; // 1 day
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface SlowQueryRecord {
+  timestamp: string;        // ISO-8601
+  queryType: string;        // label supplied by caller
+  sql: string;              // full query text
+  params: unknown[];        // bound parameters
+  durationMs: number;
+  explainAnalyze?: string;  // EXPLAIN ANALYZE output for very slow queries
+}
+
+export interface DbHistogramBucket {
+  le: number;    // upper bound in seconds
+  count: number; // cumulative count of observations ≤ le
+}
+
+export interface DbQueryMetrics {
+  queryType: string;
+  count: number;
+  sum_seconds: number;
+  buckets: DbHistogramBucket[];
+  p99_estimate_seconds: number | null;
+}
+
+// ── Histogram helpers ─────────────────────────────────────────────────────────
+
+type HistogramData = Record<
+  string, // queryType
+  {
+    count: number;
+    sum: number;  // seconds
+    buckets: Record<string, number>; // "0.1" → cumulative count
+  }
+>;
+
+async function recordObservation(
+  queryType: string,
+  durationMs: number
+): Promise<void> {
+  const durationSec = durationMs / 1000;
+
+  let data: HistogramData = {};
+  try {
+    const cached = await cacheGet<HistogramData>(METRICS_NS, HISTOGRAM_KEY);
+    if (cached) data = cached;
+  } catch {
+    // ignore Redis error
+  }
+
+  if (!data[queryType]) {
+    data[queryType] = {
+      count: 0,
+      sum: 0,
+      buckets: Object.fromEntries(HISTOGRAM_BUCKETS.map((b) => [String(b), 0])),
+    };
+  }
+
+  data[queryType].count += 1;
+  data[queryType].sum += durationSec;
+
+  // Increment all buckets whose upper bound ≥ durationSec (cumulative)
+  for (const bucket of HISTOGRAM_BUCKETS) {
+    if (durationSec <= bucket) {
+      data[queryType].buckets[String(bucket)] += 1;
+    }
+  }
+
+  try {
+    await cacheSet(METRICS_NS, HISTOGRAM_KEY, data, METRICS_TTL);
+  } catch {
+    // best-effort
+  }
+}
+
+// ── Slow query log helpers ────────────────────────────────────────────────────
+
+async function appendSlowQuery(record: SlowQueryRecord): Promise<void> {
+  let log: SlowQueryRecord[] = [];
+  try {
+    const cached = await cacheGet<SlowQueryRecord[]>(METRICS_NS, SLOW_LOG_KEY);
+    if (cached) log = cached;
+  } catch {
+    // ignore Redis error
+  }
+
+  log.push(record);
+
+  // Keep only the most recent SLOW_LOG_MAX_ENTRIES entries
+  if (log.length > SLOW_LOG_MAX_ENTRIES) {
+    log = log.slice(log.length - SLOW_LOG_MAX_ENTRIES);
+  }
+
+  try {
+    await cacheSet(METRICS_NS, SLOW_LOG_KEY, log, SLOW_LOG_TTL);
+  } catch {
+    // best-effort
+  }
+}
+
+// ── EXPLAIN ANALYZE capture ───────────────────────────────────────────────────
+
+async function captureExplainAnalyze(
+  pool: pg.Pool,
+  sql: string,
+  params: unknown[]
+): Promise<string> {
+  try {
+    // Only safe for SELECT statements to avoid side-effects
+    const normalized = sql.trim().toUpperCase();
+    if (!normalized.startsWith("SELECT")) {
+      return "(EXPLAIN skipped — not a SELECT)";
+    }
+
+    const result = await pool.query(
+      `EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) ${sql}`,
+      params
+    );
+
+    return (result.rows as Array<{ "QUERY PLAN": string }>)
+      .map((r) => r["QUERY PLAN"])
+      .join("\n");
+  } catch (err) {
+    return `(EXPLAIN failed: ${String(err)})`;
+  }
+}
+
+// ── Core instrumentation ──────────────────────────────────────────────────────
+
+/**
+ * Execute a query with monitoring.
+ *
+ * @param pool      - pg.Pool to run the query on
+ * @param sql       - SQL text (parameterised with $1, $2, …)
+ * @param params    - Bound parameters array
+ * @param queryType - Human-readable label for metrics (e.g. "list_positions")
+ */
+export async function instrumentedQuery<T extends pg.QueryResultRow = pg.QueryResultRow>(
+  pool: pg.Pool,
+  sql: string,
+  params: unknown[] = [],
+  queryType = "unknown"
+): Promise<pg.QueryResult<T>> {
+  const start = Date.now();
+
+  let result: pg.QueryResult<T>;
+  let queryError: unknown = null;
+
+  try {
+    result = await pool.query<T>(sql, params);
+  } catch (err) {
+    queryError = err;
+    // Still record timing even on error
+    const durationMs = Date.now() - start;
+    logger.error("[db-monitor] query error", {
+      queryType,
+      durationMs,
+      sql: sql.slice(0, 500), // truncate very long SQL
+      error: String(err),
+    });
+    await recordObservation(queryType, durationMs).catch(() => undefined);
+    throw err;
+  }
+
+  const durationMs = Date.now() - start;
+
+  // Record histogram observation (best-effort)
+  void recordObservation(queryType, durationMs);
+
+  if (durationMs >= SLOW_QUERY_THRESHOLD_MS) {
+    const record: SlowQueryRecord = {
+      timestamp: new Date().toISOString(),
+      queryType,
+      sql,
+      params,
+      durationMs,
+    };
+
+    // For very slow queries also capture EXPLAIN ANALYZE
+    if (durationMs >= EXPLAIN_THRESHOLD_MS) {
+      record.explainAnalyze = await captureExplainAnalyze(pool, sql, params);
+
+      logger.warn("[db-monitor] SLOW QUERY (with EXPLAIN ANALYZE)", {
+        queryType,
+        durationMs,
+        sql,
+        params,
+        explainAnalyze: record.explainAnalyze,
+      });
+    } else {
+      logger.warn("[db-monitor] slow query", {
+        queryType,
+        durationMs,
+        sql,
+        params,
+      });
+    }
+
+    void appendSlowQuery(record);
+  }
+
+  return result;
+}
+
+// ── Pool wrapper ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns an object that delegates .query() to instrumentedQuery.
+ * Useful for swapping in a monitored pool without changing call sites.
+ */
+export function wrapPool(
+  pool: pg.Pool,
+  poolLabel = "default"
+): {
+  query: <T extends pg.QueryResultRow = pg.QueryResultRow>(
+    sql: string,
+    params?: unknown[],
+    queryType?: string
+  ) => Promise<pg.QueryResult<T>>;
+} {
+  return {
+    query: <T extends pg.QueryResultRow>(
+      sql: string,
+      params: unknown[] = [],
+      queryType = poolLabel
+    ) => instrumentedQuery<T>(pool, sql, params, queryType),
+  };
+}
+
+// ── Metrics read API ──────────────────────────────────────────────────────────
+
+/**
+ * Returns aggregated histogram metrics for all query types.
+ * Consumed by the /api/v1/vault/metrics/db endpoint.
+ */
+export async function getDbMetrics(): Promise<DbQueryMetrics[]> {
+  let data: HistogramData = {};
+  try {
+    const cached = await cacheGet<HistogramData>(METRICS_NS, HISTOGRAM_KEY);
+    if (cached) data = cached;
+  } catch {
+    return [];
+  }
+
+  return Object.entries(data).map(([queryType, d]) => {
+    // Estimate p99 from buckets using linear interpolation
+    const target = d.count * 0.99;
+    let p99: number | null = null;
+    for (const bucket of HISTOGRAM_BUCKETS) {
+      if ((d.buckets[String(bucket)] ?? 0) >= target) {
+        p99 = bucket;
+        break;
+      }
+    }
+    if (p99 === null && d.count > 0) {
+      p99 = HISTOGRAM_BUCKETS[HISTOGRAM_BUCKETS.length - 1] ?? null;
+    }
+
+    return {
+      queryType,
+      count: d.count,
+      sum_seconds: d.sum,
+      buckets: HISTOGRAM_BUCKETS.map((le) => ({
+        le,
+        count: d.buckets[String(le)] ?? 0,
+      })),
+      p99_estimate_seconds: p99,
+    };
+  });
+}
+
+/**
+ * Returns the slow query log (most recent first).
+ */
+export async function getSlowQueryLog(): Promise<SlowQueryRecord[]> {
+  try {
+    const log = await cacheGet<SlowQueryRecord[]>(METRICS_NS, SLOW_LOG_KEY);
+    return log ? [...log].reverse() : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Returns Prometheus text format exposition for db_query_duration_seconds.
+ * Suitable for inclusion in the /metrics scrape endpoint.
+ */
+export async function dbMetricsPrometheusText(): Promise<string> {
+  const metrics = await getDbMetrics();
+  const lines: string[] = [
+    "# HELP db_query_duration_seconds Duration of database queries in seconds",
+    "# TYPE db_query_duration_seconds histogram",
+  ];
+
+  for (const m of metrics) {
+    const label = `query_type="${m.queryType}"`;
+    for (const b of m.buckets) {
+      lines.push(
+        `db_query_duration_seconds_bucket{${label},le="${b.le}"} ${b.count}`
+      );
+    }
+    lines.push(`db_query_duration_seconds_bucket{${label},le="+Inf"} ${m.count}`);
+    lines.push(`db_query_duration_seconds_sum{${label}} ${m.sum_seconds}`);
+    lines.push(`db_query_duration_seconds_count{${label}} ${m.count}`);
+  }
+
+  return lines.join("\n");
+}

--- a/monitoring/grafana/dashboards/db-query-performance.json
+++ b/monitoring/grafana/dashboards/db-query-performance.json
@@ -1,0 +1,148 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "aura-db-query-perf",
+    "title": "Aura Vault - DB Query Performance",
+    "description": "Database query performance monitoring — issue #324. Shows p50/p95/p99 latency per query type, slow query log, and query rate.",
+    "tags": ["aura-vault", "database", "performance"],
+    "timezone": "browser",
+    "refresh": "1m",
+    "time": { "from": "now-7d", "to": "now" },
+    "panels": [
+      {
+        "id": 1,
+        "title": "p99 Query Duration by Type",
+        "type": "timeseries",
+        "description": "99th percentile query duration per query_type label. Alert fires when this exceeds 500ms.",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.99, rate(db_query_duration_seconds_bucket[5m]))",
+            "legendFormat": "p99 {{query_type}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.1 },
+                { "color": "orange", "value": 0.25 },
+                { "color": "red", "value": 0.5 }
+              ]
+            }
+          }
+        },
+        "options": {
+          "tooltip": { "mode": "multi" }
+        }
+      },
+      {
+        "id": 2,
+        "title": "p50 / p95 Query Duration by Type",
+        "type": "timeseries",
+        "description": "Median and 95th-percentile query duration for all labeled query types.",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, rate(db_query_duration_seconds_bucket[5m]))",
+            "legendFormat": "p50 {{query_type}}"
+          },
+          {
+            "expr": "histogram_quantile(0.95, rate(db_query_duration_seconds_bucket[5m]))",
+            "legendFormat": "p95 {{query_type}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": { "unit": "s" }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Query Rate (per second)",
+        "type": "timeseries",
+        "description": "Number of DB queries per second, segmented by query_type.",
+        "gridPos": { "h": 6, "w": 12, "x": 0, "y": 8 },
+        "targets": [
+          {
+            "expr": "rate(db_query_duration_seconds_count[5m])",
+            "legendFormat": "{{query_type}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": { "unit": "ops" }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Slow Query Count (>100ms) — 7-day weekly view",
+        "type": "barchart",
+        "description": "Weekly bar chart of queries exceeding 100ms. Useful for the weekly slow query report.",
+        "gridPos": { "h": 6, "w": 12, "x": 12, "y": 8 },
+        "targets": [
+          {
+            "expr": "increase(db_query_duration_seconds_bucket{le=\"0.1\"}[1d])",
+            "legendFormat": "queries ≤ 100ms {{query_type}}"
+          },
+          {
+            "expr": "increase(db_query_duration_seconds_count[1d]) - increase(db_query_duration_seconds_bucket{le=\"0.1\"}[1d])",
+            "legendFormat": "queries > 100ms {{query_type}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": { "unit": "short" }
+        },
+        "options": {
+          "groupWidth": 0.7,
+          "barWidth": 0.97
+        }
+      },
+      {
+        "id": 5,
+        "title": "p99 Query Duration — Current Value",
+        "type": "stat",
+        "description": "Current p99 query latency across all query types. Alerts when > 500ms.",
+        "gridPos": { "h": 4, "w": 6, "x": 0, "y": 14 },
+        "targets": [
+          {
+            "expr": "max(histogram_quantile(0.99, rate(db_query_duration_seconds_bucket[5m])))",
+            "legendFormat": "max p99"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 0.1 },
+                { "color": "red", "value": 0.5 }
+              ]
+            },
+            "mappings": []
+          }
+        },
+        "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+      },
+      {
+        "id": 6,
+        "title": "Total Queries (24h)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 6, "y": 14 },
+        "targets": [
+          {
+            "expr": "sum(increase(db_query_duration_seconds_count[24h]))",
+            "legendFormat": "total"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": { "unit": "short" }
+        },
+        "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+      }
+    ]
+  },
+  "folderId": null,
+  "overwrite": true
+}

--- a/monitoring/prometheus/alert.rules.yml
+++ b/monitoring/prometheus/alert.rules.yml
@@ -273,3 +273,41 @@ groups:
             were processed. Some funds remain in lending protocols. Re-run
             emergencyWithdrawAll() with higher gas or process remaining tokens
             individually. Instance: {{ $labels.instance }}.
+
+  # ── DB Query Performance — Issue #324 ────────────────────────────────────
+  - name: aura-vault-db-performance
+    rules:
+      - alert: SlowDatabaseQueryP99
+        expr: >
+          histogram_quantile(0.99,
+            rate(db_query_duration_seconds_bucket[5m])
+          ) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+          team: backend
+        annotations:
+          summary: "p99 DB query time exceeds 500ms"
+          description: >
+            The 99th-percentile database query duration has exceeded 500 ms for
+            5 consecutive minutes (current: {{ $value | humanizeDuration }}).
+            Query type: {{ $labels.query_type }}.
+            Check the slow query log at /api/v1/vault/metrics/db/slow-log.
+          runbook_url: "https://github.com/soterika/aura-vault-protocol/wiki/runbooks/SlowDatabaseQuery"
+
+      - alert: SlowDatabaseQueryP50
+        expr: >
+          histogram_quantile(0.50,
+            rate(db_query_duration_seconds_bucket[5m])
+          ) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          team: backend
+        annotations:
+          summary: "Median DB query time exceeds 100ms"
+          description: >
+            The median (p50) database query duration has exceeded 100 ms for
+            10 consecutive minutes (current: {{ $value | humanizeDuration }}).
+            This may indicate missing indexes or N+1 query patterns.
+          runbook_url: "https://github.com/soterika/aura-vault-protocol/wiki/runbooks/SlowDatabaseQuery"


### PR DESCRIPTION
…324)

- Add dbMonitor.ts: instrumentedQuery() wraps pg.Pool.query with timing
- Queries >100ms logged at WARN with full SQL and params
- Queries >500ms also capture EXPLAIN ANALYZE output (SELECT only)
- Prometheus histogram: db_query_duration_seconds with query_type label
- Slow query log stored in Redis (last 200 entries, 7-day retention)
- New vault routes: GET /api/v1/vault/metrics/db, /metrics/db/slow-log, /metrics/db/prometheus (Prometheus text format)
- Grafana dashboard: db-query-performance.json (p99/p95/p50, rate, weekly bar)
- Prometheus alert rules: SlowDatabaseQueryP99 (>500ms for 5m), SlowDatabaseQueryP50 (>100ms for 10m)

closes #324 