### PR TITLE
feat(vault): implement emergency_withdraw for trust-minimized exit

### DIFF
--- a/aura-vault/src/emergency_withdraw_test.rs
+++ b/aura-vault/src/emergency_withdraw_test.rs
@@ -1,0 +1,309 @@
+//! Tests for `emergency_withdraw` — Issue #344
+//!
+//! Acceptance criteria verified:
+//!   1. Only callable when vault IS paused  → NotVaultPaused when unpaused
+//!   2. Burns shares and transfers pro-rata vault balance  → exact amount
+//!   3. No fee deducted  → full pro-rata received
+//!   4. EmergencyWithdraw event emitted  → event topic check
+//!   5. Cannot be disabled by admin  → no admin guard in the function
+//!   6. Correct share/balance state after withdrawal
+
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+use soroban_sdk::token::StellarAssetClient;
+
+use crate::{AuraVault, AuraVaultClient, VaultError};
+
+// ---------------------------------------------------------------------------
+// Helper — same as test.rs setup() but defined locally to avoid import issues.
+// ---------------------------------------------------------------------------
+
+fn setup() -> (Env, AuraVaultClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_address = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    let vault_address = env.register_contract(None, AuraVault);
+    let vault = AuraVaultClient::new(&env, &vault_address);
+
+    let signers: Vec<Address> = Vec::new(&env);
+    vault.initialize(&admin, &token_address, &signers);
+    // Zero fees so arithmetic is exact
+    vault.set_fees(&admin, &0_u32, &0_u32);
+
+    (env, vault, admin, token_address)
+}
+
+fn mint(env: &Env, token: &Address, admin: &Address, recipient: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(recipient, &amount);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Requires vault to be paused
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_emergency_withdraw_fails_when_not_paused() {
+    let (env, vault, _admin, token) = setup();
+    let user = Address::generate(&env);
+
+    // Deposit so user has shares
+    mint(&env, &token, &_admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+
+    // Vault is NOT paused — should return NotVaultPaused
+    let result = vault.try_emergency_withdraw(&user, &500_000);
+    assert_eq!(result, Err(Ok(VaultError::NotVaultPaused)));
+}
+
+#[test]
+fn test_emergency_withdraw_succeeds_when_paused() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+    vault.pause(&admin);
+
+    // Should succeed now
+    let result = vault.try_emergency_withdraw(&user, &500_000);
+    assert!(result.is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// 2. Pro-rata amount: shares × actual_balance / total_shares
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_emergency_withdraw_pro_rata_single_user() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    // Deposit 1_000_000 → receives 1_000_000 shares (1:1 seed)
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+
+    vault.pause(&admin);
+
+    // total_shares = 1_000_000, actual_balance = 1_000_000
+    // redeem(500_000 shares) = 500_000 × 1_000_000 / 1_000_000 = 500_000
+    let received = vault.emergency_withdraw(&user, &500_000);
+    assert_eq!(received, 500_000);
+    assert_eq!(vault.balance_of(&user), 500_000);
+}
+
+#[test]
+fn test_emergency_withdraw_pro_rata_full_balance() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    mint(&env, &token, &admin, &user, 2_000_000);
+    vault.deposit(&user, &2_000_000);
+
+    vault.pause(&admin);
+
+    // Withdraw all shares — should receive the full balance
+    let received = vault.emergency_withdraw(&user, &2_000_000);
+    assert_eq!(received, 2_000_000);
+    assert_eq!(vault.balance_of(&user), 0);
+    assert_eq!(vault.total_shares(), 0);
+}
+
+#[test]
+fn test_emergency_withdraw_pro_rata_two_users() {
+    let (env, vault, admin, token) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    // Alice deposits 3_000_000, Bob deposits 1_000_000
+    // total_shares = 4_000_000, total_deposited = 4_000_000
+    mint(&env, &token, &admin, &alice, 3_000_000);
+    mint(&env, &token, &admin, &bob, 1_000_000);
+    vault.deposit(&alice, &3_000_000);
+    vault.deposit(&bob, &1_000_000);
+
+    vault.pause(&admin);
+
+    // Alice has 3_000_000 / 4_000_000 = 75% of the vault
+    // Emergency withdraw all alice's shares:
+    // redeem = 3_000_000 × 4_000_000 / 4_000_000 = 3_000_000
+    let alice_received = vault.emergency_withdraw(&alice, &3_000_000);
+    assert_eq!(alice_received, 3_000_000);
+
+    // Bob still has 1_000_000 shares; remaining balance is 1_000_000
+    assert_eq!(vault.balance_of(&bob), 1_000_000);
+    assert_eq!(vault.total_shares(), 1_000_000);
+}
+
+// ---------------------------------------------------------------------------
+// 3. No fee deducted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_emergency_withdraw_no_fee_even_when_fee_configured() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    // Configure a 10% performance fee and a 5% withdrawal fee
+    vault.set_fees(&admin, &1000_u32, &0_u32);
+    vault.set_withdrawal_fee(&admin, &500_u32);
+
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+
+    vault.pause(&admin);
+
+    // Emergency path — no fee applied
+    // redeem = 1_000_000 × 1_000_000 / 1_000_000 = 1_000_000 (full amount)
+    let received = vault.emergency_withdraw(&user, &1_000_000);
+    assert_eq!(received, 1_000_000, "emergency_withdraw must not deduct any fee");
+}
+
+// ---------------------------------------------------------------------------
+// 4. EmergencyWithdraw event emitted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_emergency_withdraw_emits_event() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+    vault.pause(&admin);
+
+    vault.emergency_withdraw(&user, &1_000_000);
+
+    // Verify the "emergency_withdraw" event was published.
+    // Soroban test env stores events; we check that at least one has the
+    // expected topic symbol.
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        // Each event is (contract_id, topics, data).
+        // topics is a Vec<Val> — the first entry is the event name symbol.
+        let topics_raw = e.1.clone();
+        // Convert to string for easy matching
+        let topics_str = std::format!("{:?}", topics_raw);
+        topics_str.contains("emergency_withdraw")
+    });
+    assert!(found, "emergency_withdraw event was not emitted");
+}
+
+// ---------------------------------------------------------------------------
+// 5. Cannot be disabled — no admin guard (structural check)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_emergency_withdraw_non_admin_can_call_when_paused() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+
+    // non_admin has no special permissions
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+
+    // Give non_admin shares too
+    mint(&env, &token, &admin, &non_admin, 500_000);
+    vault.deposit(&non_admin, &500_000);
+
+    vault.pause(&admin);
+
+    // non_admin is not the vault admin but can still call emergency_withdraw
+    let result = vault.try_emergency_withdraw(&non_admin, &500_000);
+    assert!(
+        result.is_ok(),
+        "non-admin should be able to call emergency_withdraw when paused: {:?}",
+        result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_emergency_withdraw_zero_shares_rejected() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+    vault.pause(&admin);
+
+    let result = vault.try_emergency_withdraw(&user, &0);
+    assert_eq!(result, Err(Ok(VaultError::ZeroAmount)));
+}
+
+#[test]
+fn test_emergency_withdraw_insufficient_shares_rejected() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+    vault.pause(&admin);
+
+    // User has 1_000_000 shares, tries to withdraw 2_000_000
+    let result = vault.try_emergency_withdraw(&user, &2_000_000);
+    assert_eq!(result, Err(Ok(VaultError::InsufficientShares)));
+}
+
+#[test]
+fn test_emergency_withdraw_requires_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let vault_address = env.register_contract(None, AuraVault);
+    let vault = AuraVaultClient::new(&env, &vault_address);
+    let user = Address::generate(&env);
+
+    // Not initialized
+    let result = vault.try_emergency_withdraw(&user, &1_000);
+    assert_eq!(result, Err(Ok(VaultError::NotInitialized)));
+}
+
+// ---------------------------------------------------------------------------
+// 7. State consistency after emergency withdrawal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_emergency_withdraw_updates_total_shares() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+
+    assert_eq!(vault.total_shares(), 1_000_000);
+    vault.pause(&admin);
+
+    vault.emergency_withdraw(&user, &600_000);
+
+    assert_eq!(vault.total_shares(), 400_000);
+    assert_eq!(vault.balance_of(&user), 400_000);
+}
+
+#[test]
+fn test_emergency_withdraw_partial_then_unpause_normal_withdraw() {
+    let (env, vault, admin, token) = setup();
+    let user = Address::generate(&env);
+
+    mint(&env, &token, &admin, &user, 1_000_000);
+    vault.deposit(&user, &1_000_000);
+
+    // Pause and do an emergency partial withdrawal
+    vault.pause(&admin);
+    vault.emergency_withdraw(&user, &500_000);
+
+    // Unpause and do a normal withdrawal with remaining shares
+    vault.unpause(&admin);
+    let result = vault.try_withdraw(&user, &500_000);
+    assert!(result.is_ok(), "normal withdraw should work after unpause: {:?}", result);
+}

--- a/aura-vault/src/errors.rs
+++ b/aura-vault/src/errors.rs
@@ -260,4 +260,102 @@ pub enum VaultError {
     /// Oracle data is stale: the `updated_at` timestamp is older than the
     /// configured maximum age.
     OraclePriceStale       = 27,
+
+    // -----------------------------------------------------------------------
+    // 28: Circuit-breaker error (Issue #371)
+    // -----------------------------------------------------------------------
+
+    /// A harvest was blocked and the vault was auto-paused because the
+    /// share price movement exceeded the configured circuit-breaker threshold.
+    ///
+    /// **Trigger:** `harvest` would change the share price by more than the
+    /// `price_movement_limit` basis points set via `set_price_movement_limit`.
+    ///
+    /// **Resolution:** The vault is now paused. The admin should investigate
+    /// the large price movement and call `unpause()` once it has been reviewed.
+    CircuitBreakerTripped  = 28,
+
+    // -----------------------------------------------------------------------
+    // 29: Emergency-withdrawal precondition error (Issue #344)
+    // -----------------------------------------------------------------------
+
+    /// `emergency_withdraw` requires the vault to be paused, but it is not.
+    ///
+    /// **Trigger:** `emergency_withdraw` called while `is_paused()` returns
+    /// `false`. The emergency exit path is only available during a pause to
+    /// ensure it is used as a last resort.
+    ///
+    /// **Resolution:** Wait for the admin to pause the vault, then retry. If
+    /// you want a normal withdrawal, use `withdraw` instead.
+    NotVaultPaused         = 29,
+}
+
+impl VaultError {
+    /// Return the human-readable English description for this error variant.
+    ///
+    /// These strings are embedded in the contract ABI and surfaced by
+    /// `get_vault_error_message` so wallet and explorer UIs can display
+    /// friendly messages without a separate lookup table.
+    pub fn message(self) -> &'static str {
+        match self {
+            VaultError::NotInitialized =>
+                "Vault has not been initialised; call initialize() first.",
+            VaultError::AlreadyInitialized =>
+                "Vault is already initialised; initialize() may only be called once.",
+            VaultError::InsufficientShares =>
+                "Caller does not hold enough shares to fulfil this withdrawal.",
+            VaultError::InsufficientUnderlying =>
+                "Vault cannot cover the redemption; tracked balance is too low.",
+            VaultError::ZeroAmount =>
+                "Amount must be greater than zero, or deposit is too small to mint shares.",
+            VaultError::MathOverflow =>
+                "Arithmetic overflow in share formula; reduce the transaction amount.",
+            VaultError::InvalidAddress =>
+                "Address is not valid or not on the required whitelist.",
+            VaultError::ZeroShares =>
+                "No shares outstanding; wait for the first depositor before harvesting.",
+            VaultError::UpgradeUnauthorized =>
+                "Caller is not the vault admin.",
+            VaultError::StorageLayoutMismatch =>
+                "Storage layout version mismatch; perform migration before upgrading.",
+            VaultError::VaultPaused =>
+                "All mutating operations are halted; the vault is currently paused.",
+            VaultError::BalanceMismatch =>
+                "Actual token balance differs from tracked state (flash-loan guard tripped).",
+            VaultError::TimelockNotExpired =>
+                "Governance timelock has not elapsed; wait before executing this proposal.",
+            VaultError::NotApproved =>
+                "Governance proposal has not reached the required approval threshold.",
+            VaultError::AlreadyVoted =>
+                "This signer has already voted on this proposal.",
+            VaultError::TvlCapExceeded =>
+                "Deposit would exceed the vault TVL cap; try a smaller amount.",
+            VaultError::YieldTooSmall =>
+                "Yield amount is too small to distribute; it rounds to zero per share.",
+            VaultError::DistributionAccuracyError =>
+                "Yield distribution rounding error exceeds the 0.01% accuracy threshold.",
+            VaultError::HarvestCooldown =>
+                "Harvest attempted before the configured cooldown period has elapsed.",
+            VaultError::WithdrawalQueued =>
+                "Withdrawal is queued; call claim_queued_withdrawal after the unbonding period.",
+            VaultError::QueueEntryNotFound =>
+                "Withdrawal queue entry does not exist or has already been claimed.",
+            VaultError::QueueUnbondingPending =>
+                "Withdrawal queue entry is still within the unbonding period.",
+            VaultError::InvalidWithdrawalFee =>
+                "Withdrawal fee rate exceeds the maximum allowed (500 bps / 5%).",
+            VaultError::TransferFailed =>
+                "Token transfer did not move the expected amount (fee-on-transfer token?).",
+            VaultError::OraclePriceZero =>
+                "Oracle price is zero; feed may be dead or returning invalid data.",
+            VaultError::OraclePriceTooHigh =>
+                "Oracle price exceeds sanity cap; possible feed misconfiguration or manipulation.",
+            VaultError::OraclePriceStale =>
+                "Oracle price is stale; updated_at timestamp exceeds the maximum allowed age.",
+            VaultError::CircuitBreakerTripped =>
+                "Share price movement exceeded the circuit-breaker threshold; vault auto-paused.",
+            VaultError::NotVaultPaused =>
+                "emergency_withdraw requires the vault to be paused; use withdraw() instead.",
+        }
+    }
 }

--- a/aura-vault/src/interface.rs
+++ b/aura-vault/src/interface.rs
@@ -481,6 +481,46 @@ pub trait AuraVaultTrait {
     /// - `proposal_id` — ID of the proposal to query.
     fn proposal_status(env: Env, proposal_id: u64) -> Option<String>;
 
+    /// Emergency withdrawal — only available when the vault is paused.
+    ///
+    /// Burns `shares` from the caller and transfers a pro-rata share of the
+    /// vault's **actual on-chain token balance** (not the tracked
+    /// `total_deposited`). This bypasses strategy positions so users can exit
+    /// even when the vault cannot source liquidity through normal means.
+    ///
+    /// Key properties:
+    /// - **Only callable when `is_paused() == true`.**  Returns
+    ///   [`VaultError::NotVaultPaused`] if the vault is not paused.
+    /// - **No fee** — performance and withdrawal fees are waived.
+    /// - **Cannot be disabled** — the admin has no way to block this path.
+    ///   Once the vault is paused, any shareholder may call it.
+    /// - Pro-rata formula: `redeem = floor(shares × actual_balance / total_shares)`
+    ///   where `actual_balance` is the live on-chain token balance.
+    ///
+    /// Emits an `emergency_withdraw` event with topics
+    /// `(event_name, caller, shares)` and data
+    /// `(redeem_amount, new_total_shares, actual_balance_before)`.
+    ///
+    /// # Parameters
+    ///
+    /// - `env` — Soroban execution environment.
+    /// - `caller` — Address redeeming shares; must authorise this call.
+    /// - `shares` — Number of vault shares to burn. Must be > 0 and ≤
+    ///   `balance_of(caller)`.
+    ///
+    /// # Returns
+    ///
+    /// The number of underlying tokens transferred to `caller`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault has not been initialised.
+    /// - [`VaultError::NotVaultPaused`] — vault is not paused.
+    /// - [`VaultError::ZeroAmount`] — `shares <= 0`, or redemption rounds to zero.
+    /// - [`VaultError::InsufficientShares`] — caller holds fewer shares than requested.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow.
+    fn emergency_withdraw(env: Env, caller: Address, shares: i128) -> Result<i128, VaultError>;
+
     /// Return the human-readable English message for a given [`VaultError`]
     /// code, or `None` if the code does not correspond to a known variant.
     ///

--- a/aura-vault/src/lib.rs
+++ b/aura-vault/src/lib.rs
@@ -57,7 +57,10 @@ mod harvest_cooldown_test;
 #[cfg(test)]
 mod pause_lifecycle_test;
 #[cfg(test)]
-mod circuit_breaker_test;#[cfg(test)]
+mod circuit_breaker_test;
+#[cfg(test)]
+mod emergency_withdraw_test;
+#[cfg(test)]
 mod event_test;
 #[cfg(test)]
 mod event_snapshots;
@@ -1893,6 +1896,119 @@ impl AuraVault {
     }
 
     // -----------------------------------------------------------------------
+    // emergency_withdraw — trust-minimized exit during pause (Issue #344)
+    //
+    // Allows any shareholder to redeem shares for a pro-rata portion of the
+    // vault's actual on-chain token balance when the vault is paused.
+    //
+    // Properties:
+    //   - Only callable when vault IS paused (opposite of normal ops).
+    //   - Redemption is based on actual token.balance() not total_deposited,
+    //     so it works even if total_deposited is out of sync.
+    //   - No fee of any kind (trust-minimized escape hatch).
+    //   - Cannot be disabled by the admin — any paused vault allows it.
+    //   - CEI ordering: state written before token transfer.
+    //   - Emits emergency_withdraw event.
+    // -----------------------------------------------------------------------
+    /// Emergency withdrawal — only callable when the vault is paused.
+    ///
+    /// Burns `shares` and transfers `floor(shares × actual_balance / total_shares)`
+    /// underlying tokens to `caller`. No fee. Cannot be disabled.
+    ///
+    /// # Errors
+    ///
+    /// - [`VaultError::NotInitialized`] — vault not yet initialised.
+    /// - [`VaultError::NotVaultPaused`] — vault is not paused.
+    /// - [`VaultError::ZeroAmount`] — `shares <= 0` or redemption rounds to 0.
+    /// - [`VaultError::InsufficientShares`] — caller holds fewer shares than requested.
+    /// - [`VaultError::MathOverflow`] — arithmetic overflow.
+    pub fn emergency_withdraw(env: Env, caller: Address, shares: i128) -> Result<i128, VaultError> {
+        caller.require_auth();
+
+        // Must be initialised
+        if get_admin(&env).is_none() {
+            return Err(VaultError::NotInitialized);
+        }
+
+        // Require vault to be paused — this is the emergency path
+        if !storage_is_paused(&env) {
+            return Err(VaultError::NotVaultPaused);
+        }
+
+        if shares <= 0 {
+            return Err(VaultError::ZeroAmount);
+        }
+
+        let user_balance = get_balance(&env, &caller);
+        if shares > user_balance {
+            return Err(VaultError::InsufficientShares);
+        }
+
+        let total_shares = get_total_shares(&env);
+        // total_shares must be > 0 if user has shares, but guard anyway
+        if total_shares == 0 {
+            return Err(VaultError::ZeroAmount);
+        }
+
+        let token_addr = get_token(&env).ok_or(VaultError::NotInitialized)?;
+        let token = token::Client::new(&env, &token_addr);
+        let vault_addr = env.current_contract_address();
+
+        // Use actual on-chain balance, not total_deposited, so this works
+        // even if the vault's accounting diverged from reality.
+        let actual_balance = token.balance(&vault_addr);
+
+        // pro-rata: floor(shares × actual_balance / total_shares)
+        let numerator = shares
+            .checked_mul(actual_balance)
+            .ok_or(VaultError::MathOverflow)?;
+        let redeem_amount = numerator
+            .checked_div(total_shares)
+            .ok_or(VaultError::MathOverflow)?;
+
+        if redeem_amount <= 0 {
+            return Err(VaultError::ZeroAmount);
+        }
+
+        // CEI — Effects: burn shares and update accounting before transfer
+        let new_user_balance = user_balance
+            .checked_sub(shares)
+            .ok_or(VaultError::MathOverflow)?;
+        set_balance(&env, &caller, new_user_balance);
+
+        let new_total_shares = total_shares
+            .checked_sub(shares)
+            .ok_or(VaultError::MathOverflow)?;
+        set_total_shares(&env, new_total_shares);
+
+        // Also reduce total_deposited proportionally so share math stays
+        // consistent for any remaining shareholders.
+        let total_deposited = get_total_deposited(&env);
+        let new_total_deposited = total_deposited
+            .checked_sub(redeem_amount)
+            .unwrap_or(0)
+            .max(0);
+        set_total_deposited(&env, new_total_deposited);
+
+        bump_persistent(&env, &caller);
+        bump_instance(&env);
+
+        // Interaction: transfer tokens to caller after state is settled
+        let pre_withdraw_balance = token.balance(&vault_addr);
+        token.transfer(&vault_addr, &caller, &redeem_amount);
+        assert_outgoing_transfer(&token, &vault_addr, pre_withdraw_balance, redeem_amount)?;
+
+        // Event: topics = (event_name, caller, shares) — indexed.
+        // data = (redeem_amount, new_total_shares, actual_balance_before_transfer)
+        env.events().publish(
+            (Symbol::new(&env, "emergency_withdraw"), caller.clone(), shares),
+            (redeem_amount, new_total_shares, actual_balance),
+        );
+
+        Ok(redeem_amount)
+    }
+
+    // -----------------------------------------------------------------------
     // total_assets  (read-only)
     // -----------------------------------------------------------------------
     /// Returns the total underlying tokens currently tracked by the vault.
@@ -2149,7 +2265,12 @@ impl AuraVault {
             21 => Some(VaultError::QueueEntryNotFound.message()),
             22 => Some(VaultError::QueueUnbondingPending.message()),
             23 => Some(VaultError::InvalidWithdrawalFee.message()),
-            24 => Some(VaultError::CircuitBreakerTripped.message()),
+            24 => Some(VaultError::TransferFailed.message()),
+            25 => Some(VaultError::OraclePriceZero.message()),
+            26 => Some(VaultError::OraclePriceTooHigh.message()),
+            27 => Some(VaultError::OraclePriceStale.message()),
+            28 => Some(VaultError::CircuitBreakerTripped.message()),
+            29 => Some(VaultError::NotVaultPaused.message()),
             _  => None,
         };
         msg.map(|s| soroban_sdk::String::from_str(&env, s))


### PR DESCRIPTION
## Summary

Implements an emergency withdrawal path that lets users redeem shares for a proportional share of whatever tokens are in the vault, bypassing strategy positions and fee deduction.

## Changes

### `aura-vault/src/errors.rs`
- Added `CircuitBreakerTripped = 28` — was used in `lib.rs` and tests but missing from the enum (pre-existing bug fixed)
- Added `NotVaultPaused = 29` — returned by `emergency_withdraw` when the vault is not paused
- Implemented `VaultError::message()` for all 29 variants (was referenced in ABI but never defined)

### `aura-vault/src/interface.rs`
- Added `emergency_withdraw(caller, shares) -> Result<i128, VaultError>` to `AuraVaultTrait` with full doc-comment

### `aura-vault/src/lib.rs`
- Implemented `AuraVault::emergency_withdraw`:
  - Requires vault to be **paused** (`NotVaultPaused` otherwise)
  - Pro-rata formula: `floor(shares × actual_balance / total_shares)` using live on-chain token balance
  - **No fee** — waives all performance and withdrawal fees
  - **Cannot be disabled** — no admin guard; any shareholder can call it while paused
  - CEI ordering: state written before token transfer
  - Emits `emergency_withdraw` event
- Fixed `get_vault_error_message`: code 24 was incorrectly mapped to `CircuitBreakerTripped` (now correctly `TransferFailed`); added codes 25–29

### `aura-vault/src/emergency_withdraw_test.rs` (new file)
12 tests covering all acceptance criteria:
- Fails with `NotVaultPaused` when vault is not paused
- Succeeds when paused
- Pro-rata: single user, full balance, two users
- No fee deducted even when perf + withdrawal fees are configured
- `emergency_withdraw` event emitted
- Non-admin can call (cannot be disabled by admin)
- `ZeroAmount`, `InsufficientShares`, `NotInitialized` error paths
- State consistency after partial withdrawal
- Partial emergency then normal `withdraw` after `unpause`

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Only callable when vault is paused | ✅ Returns `NotVaultPaused` otherwise |
| Burns shares and transfers pro-rata vault balance | ✅ Uses `actual_balance / total_shares` |
| No fee deducted | ✅ Verified in test |
| `EmergencyWithdraw` event emitted | ✅ Verified in test |
| Cannot be disabled by admin | ✅ No admin check in implementation |

Closes #344