### PR TITLE
feat(auth): implement Redis-based session blacklist for logout

### DIFF
--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -28,6 +28,7 @@ export type Tier = "free" | "paid";
 export interface TokenPayload {
   sub: string;
   sessionId: string;
+  jti?: string;       // JWT ID — unique per token, used for blacklisting
   deviceId?: string;
   tier?: Tier;
 }
@@ -43,6 +44,7 @@ interface StoredRefresh {
   sessionId: string;
   deviceId?: string;
   tier?: Tier;
+  jti: string;        // JTI of the refresh token stored alongside session data
 }
 
 export async function generateTokens(
@@ -51,9 +53,11 @@ export async function generateTokens(
   tier: Tier = "free"
 ): Promise<TokenPair> {
   const sessionId = uuidv4();
+  const accessJti = uuidv4();
+  const refreshJti = uuidv4();
 
   const accessToken = jwt.sign(
-    { sub: userId, sessionId, deviceId, tier } satisfies TokenPayload,
+    { sub: userId, sessionId, jti: accessJti, deviceId, tier } satisfies TokenPayload,
     JWT_SECRET,
     {
       expiresIn: ACCESS_TOKEN_TTL,
@@ -64,7 +68,7 @@ export async function generateTokens(
   );
 
   const refreshToken = jwt.sign(
-    { sub: userId, sessionId, type: "refresh" },
+    { sub: userId, sessionId, jti: refreshJti, type: "refresh" },
     JWT_SECRET,
     {
       expiresIn: REFRESH_TOKEN_TTL,
@@ -74,9 +78,12 @@ export async function generateTokens(
     }
   );
 
-  const stored: StoredRefresh = { userId, sessionId, deviceId, tier };
+  const stored: StoredRefresh = { userId, sessionId, deviceId, tier, jti: refreshJti };
   await cacheSet(NS.AUTH_REFRESH, refreshToken, stored, REFRESH_TOKEN_TTL);
   await setAdd(NS.AUTH_SESSIONS, userId, sessionId, REFRESH_TOKEN_TTL);
+
+  // Track refresh token reference per session for bulk revocation
+  await setAdd(NS.AUTH_SESSIONS_TOKENS, `${userId}:${sessionId}`, refreshToken, REFRESH_TOKEN_TTL);
 
   return { accessToken, refreshToken, expiresIn: ACCESS_TOKEN_TTL };
 }
@@ -84,9 +91,20 @@ export async function generateTokens(
 export async function validateAccessToken(
   token: string
 ): Promise<TokenPayload | null> {
-  const blacklisted = await cacheGet<true>(NS.AUTH_BLACKLIST, token);
-  if (blacklisted) return null;
   try {
+    // Decode first to get JTI for blacklist check
+    const decoded = jwt.decode(token) as (TokenPayload & { jti?: string }) | null;
+
+    // Check blacklist by JTI (preferred) or fall back to full token
+    if (decoded?.jti) {
+      const blacklistedByJti = await cacheGet<true>(NS.AUTH_BLACKLIST, `jti:${decoded.jti}`);
+      if (blacklistedByJti) return null;
+    }
+
+    // Also check legacy full-token blacklist entries
+    const blacklistedByToken = await cacheGet<true>(NS.AUTH_BLACKLIST, token);
+    if (blacklistedByToken) return null;
+
     return jwt.verify(token, JWT_SECRET, {
       algorithms: [JWT_ALGORITHM],
       ...(JWT_ISSUER && { issuer: JWT_ISSUER }),
@@ -100,6 +118,13 @@ export async function validateAccessToken(
 export async function refreshAccessToken(
   refreshToken: string
 ): Promise<TokenPair | null> {
+  // Check if refresh token JTI is blacklisted before proceeding
+  const decodedRefresh = jwt.decode(refreshToken) as { jti?: string; sub?: string; exp?: number } | null;
+  if (decodedRefresh?.jti) {
+    const blacklisted = await cacheGet<true>(NS.AUTH_BLACKLIST, `jti:${decodedRefresh.jti}`);
+    if (blacklisted) return null;
+  }
+
   const stored = await cacheGet<StoredRefresh>(NS.AUTH_REFRESH, refreshToken);
   if (!stored) return null;
   try {
@@ -116,25 +141,93 @@ export async function refreshAccessToken(
   return generateTokens(stored.userId, stored.deviceId, stored.tier);
 }
 
+/**
+ * Blacklist a token by its JTI (preferred) or full token string.
+ * The Redis entry TTL matches the token's remaining lifetime.
+ */
 export async function blacklistToken(token: string): Promise<void> {
-  // Use remaining token lifetime as TTL so the key auto-expires
   let ttl = ACCESS_TOKEN_TTL;
+  let jti: string | undefined;
+
   try {
-    const decoded = jwt.decode(token) as { exp?: number } | null;
+    const decoded = jwt.decode(token) as { exp?: number; jti?: string } | null;
     if (decoded?.exp) {
       const remaining = decoded.exp - Math.floor(Date.now() / 1000);
       ttl = Math.max(remaining, 1);
     }
+    jti = decoded?.jti;
   } catch {}
-  await cacheSet(NS.AUTH_BLACKLIST, token, true, ttl);
+
+  // Blacklist by JTI (small key) when available
+  if (jti) {
+    await cacheSet(NS.AUTH_BLACKLIST, `jti:${jti}`, true, ttl);
+  } else {
+    // Fall back to full token hashing for tokens without JTI
+    await cacheSet(NS.AUTH_BLACKLIST, token, true, ttl);
+  }
 }
 
+/**
+ * Blacklist a refresh token by its JTI with the refresh token's remaining TTL.
+ */
+export async function blacklistRefreshToken(refreshToken: string): Promise<void> {
+  let ttl = REFRESH_TOKEN_TTL;
+  let jti: string | undefined;
+
+  try {
+    const decoded = jwt.decode(refreshToken) as { exp?: number; jti?: string } | null;
+    if (decoded?.exp) {
+      const remaining = decoded.exp - Math.floor(Date.now() / 1000);
+      ttl = Math.max(remaining, 1);
+    }
+    jti = decoded?.jti;
+  } catch {}
+
+  if (jti) {
+    await cacheSet(NS.AUTH_BLACKLIST, `jti:${jti}`, true, ttl);
+  }
+}
+
+/**
+ * Logout: blacklist the access token and the refresh token, then remove
+ * the refresh token from the session store.
+ * Blacklist entry TTLs match each token's remaining lifetime.
+ */
 export async function logout(
   accessToken: string,
   refreshToken?: string
 ): Promise<void> {
+  // Blacklist access token
   await blacklistToken(accessToken);
-  if (refreshToken) await cacheDel(NS.AUTH_REFRESH, refreshToken);
+
+  if (refreshToken) {
+    // Blacklist refresh token JTI so it can never be used again
+    await blacklistRefreshToken(refreshToken);
+    // Remove from active session store
+    await cacheDel(NS.AUTH_REFRESH, refreshToken);
+  }
+}
+
+/**
+ * Bulk logout: revoke all active sessions for a user.
+ * Retrieves all stored refresh tokens and blacklists each one.
+ */
+export async function logoutAllDevices(userId: string): Promise<void> {
+  const sessionIds = await setMembers(NS.AUTH_SESSIONS, userId);
+
+  // For each session, find stored refresh tokens and blacklist them
+  for (const sessionId of sessionIds) {
+    const tokenSet = await setMembers(NS.AUTH_SESSIONS_TOKENS, `${userId}:${sessionId}`);
+    for (const refreshToken of tokenSet) {
+      await blacklistRefreshToken(refreshToken);
+      await cacheDel(NS.AUTH_REFRESH, refreshToken);
+    }
+    // Remove the per-session token set
+    await setDel(NS.AUTH_SESSIONS_TOKENS, `${userId}:${sessionId}`);
+  }
+
+  // Clear the session set for this user
+  await setDel(NS.AUTH_SESSIONS, userId);
 }
 
 export async function getUserSessions(userId: string): Promise<string[]> {
@@ -142,5 +235,5 @@ export async function getUserSessions(userId: string): Promise<string[]> {
 }
 
 export async function revokeAllSessions(userId: string): Promise<void> {
-  await setDel(NS.AUTH_SESSIONS, userId);
+  await logoutAllDevices(userId);
 }

--- a/backend/src/cache.ts
+++ b/backend/src/cache.ts
@@ -5,6 +5,7 @@ export const NS = {
   AUTH_BLACKLIST: "auth:blacklist",
   AUTH_REFRESH: "auth:refresh",
   AUTH_SESSIONS: "auth:sessions",
+  AUTH_SESSIONS_TOKENS: "auth:sessions:tokens", // per-session refresh token tracking for bulk logout
   API: "api",
   GAS_PRICE: "gas:price",
   GAS_HISTORY: "gas:history",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import {
   generateTokens,
   getUserSessions,
   logout,
+  logoutAllDevices,
   refreshAccessToken,
   revokeAllSessions,
   type Tier,
@@ -110,8 +111,22 @@ app.post("/api/auth/logout", authenticate, userRateLimiter(), async (req, res) =
   }
 
   const { refreshToken } = req.body;
+  // Blacklist both access token (by JTI) and refresh token (by JTI)
+  // Blacklist TTLs match each token's remaining lifetime
   await logout(token, refreshToken);
   res.json({ success: true });
+});
+
+app.post("/api/auth/logout-all", authenticate, userRateLimiter(), async (req, res) => {
+  const userId = (req as any).user?.sub;
+  if (!userId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  // Revoke all sessions: blacklists all stored refresh tokens for this user
+  await logoutAllDevices(userId);
+  res.json({ success: true, message: "All sessions revoked" });
 });
 
 app.get("/api/auth/sessions", authenticate, userRateLimiter(), async (req, res) => {


### PR DESCRIPTION
## Summary

Implements a complete Redis-based JWT session blacklist for secure logout, fulfilling all acceptance criteria from issue #309.

## What was implemented

### JTI-based blacklisting (efficient Redis keys)
- Added `jti` (JWT ID) field to both access tokens and refresh tokens via `uuid`
- `blacklistToken()` now stores a compact `auth:blacklist:jti:<uuid>` key instead of hashing the full token string
- `blacklistRefreshToken()` similarly blacklists refresh tokens by JTI with the remaining TTL

### Logout invalidates both tokens
- `logout(accessToken, refreshToken?)` blacklists the access token JTI and the refresh token JTI, then removes the refresh token from the session store
- TTLs match each token's remaining lifetime — entries auto-expire from Redis

### Bulk logout (logout all devices)
- New `logoutAllDevices(userId)` function: iterates all stored sessions and blacklists every associated refresh token JTI
- New `POST /api/auth/logout-all` endpoint wraps `logoutAllDevices()`

### Middleware checks blacklist
- `validateAccessToken()` checks JTI blacklist first, falls back to legacy full-token blacklist for backwards compatibility
- `refreshAccessToken()` checks refresh token JTI blacklist before proceeding

### Session tracking
- New `AUTH_SESSIONS_TOKENS` namespace in `cache.ts` for per-session refresh token tracking, enabling bulk revocation

## Files changed
- `backend/src/auth.ts` — full implementation
- `backend/src/cache.ts` — added `AUTH_SESSIONS_TOKENS` namespace
- `backend/src/index.ts` — added `POST /api/auth/logout-all` endpoint

Closes #309