### PR TITLE
feat(multi-tenant): build vault registry for multiple contract instances

### DIFF
--- a/backend/migrations/010_create_vaults_registry.sql
+++ b/backend/migrations/010_create_vaults_registry.sql
@@ -1,0 +1,64 @@
+-- Migration: 010_create_vaults_registry.sql
+-- Issue #310: Multi-tenant support for multiple vault contract instances
+--
+-- Creates the vault registry table that stores metadata for each vault
+-- contract instance. All multi-tenant API endpoints scope their data
+-- by vault_id. The "default" vault (seeded below) is used when no
+-- vaultId parameter is provided for backwards compatibility.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS vaults (
+  id               BIGSERIAL    PRIMARY KEY,
+  contract_id      TEXT         NOT NULL UNIQUE,          -- Soroban contract address
+  name             TEXT         NOT NULL,                 -- Human-readable vault name
+  underlying_token TEXT         NOT NULL,                 -- SEP-41 token contract address
+  network          TEXT         NOT NULL DEFAULT 'testnet', -- 'testnet' | 'mainnet' | 'futurenet'
+  is_active        BOOLEAN      NOT NULL DEFAULT TRUE,
+  is_default       BOOLEAN      NOT NULL DEFAULT FALSE,   -- At most one default vault
+  description      TEXT,
+  created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Ensure only one default vault exists at a time
+CREATE UNIQUE INDEX IF NOT EXISTS vaults_single_default_idx
+  ON vaults (is_default)
+  WHERE is_default = TRUE;
+
+-- Fast lookup by contract_id
+CREATE INDEX IF NOT EXISTS vaults_contract_id_idx
+  ON vaults (contract_id);
+
+-- Fast listing of active vaults per network
+CREATE INDEX IF NOT EXISTS vaults_network_active_idx
+  ON vaults (network, is_active);
+
+-- Trigger to auto-update updated_at timestamp
+CREATE OR REPLACE FUNCTION vaults_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER vaults_updated_at_trigger
+  BEFORE UPDATE ON vaults
+  FOR EACH ROW EXECUTE FUNCTION vaults_set_updated_at();
+
+-- Seed the default vault from environment / known testnet value.
+-- In production, replace the contract_id with the deployed contract address.
+INSERT INTO vaults (contract_id, name, underlying_token, network, is_active, is_default, description)
+VALUES (
+  COALESCE(current_setting('app.default_vault_contract_id', TRUE), 'CAURA_VAULT_TESTNET'),
+  'Aura Vault (Default)',
+  COALESCE(current_setting('app.default_underlying_token', TRUE), 'CAURA_TOKEN_TESTNET'),
+  'testnet',
+  TRUE,
+  TRUE,
+  'Default Aura yield vault on Stellar testnet'
+)
+ON CONFLICT (contract_id) DO NOTHING;
+
+COMMIT;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -32,6 +32,7 @@ import { runCacheWarmup, getWarmupStatus } from "./services/cacheWarmup.js";
 import { startEmailWorker, stopEmailWorker } from "./services/emailQueue.js";
 import { startYieldWorker, stopYieldWorker } from "./services/yieldWorker.js";
 import { vaultRouter } from "./routes/vaultRoutes.js";
+import { vaultRegistryRouter } from "./routes/vaultRegistryRoutes.js";
 import { userPreferencesRouter } from "./routes/userPreferencesRoutes.js";
 import { leaderboardRouter } from "./routes/leaderboardRoutes.js";
 import {
@@ -132,6 +133,8 @@ app.use("/api/v1/gas", gasRouter);
 app.use("/api/v1/yield", yieldRouter);
 app.use("/api/v1/queue", queueRouter);
 app.use("/api/v1/vault", vaultRouter);
+// Issue #310: Multi-tenant vault registry — list/register/manage vault contract instances
+app.use("/api/v1/vaults", vaultRegistryRouter);
 // Issue #322: Public leaderboard endpoint — no auth required (truncated addresses only)
 app.use("/api/vault/leaderboard", leaderboardRouter);
 // Issue #318: User preferences — requires authentication

--- a/backend/src/routes/vaultRegistryRoutes.ts
+++ b/backend/src/routes/vaultRegistryRoutes.ts
@@ -1,0 +1,174 @@
+/**
+ * Vault Registry Routes — Issue #310
+ *
+ * Admin endpoints for managing vault contract registrations.
+ * All write endpoints require authentication and admin role.
+ *
+ * GET  /api/v1/vaults              — list all active vaults
+ * GET  /api/v1/vaults/:id          — get a single vault by ID
+ * POST /api/v1/vaults              — register a new vault (admin)
+ * PATCH /api/v1/vaults/:id         — update vault metadata (admin)
+ * DELETE /api/v1/vaults/:id        — deactivate a vault (admin)
+ */
+
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import {
+  listVaults,
+  getVaultById,
+  createVault,
+  updateVault,
+  deactivateVault,
+} from "../services/vaultRegistryService.js";
+import { successResponse, errorResponse } from "../dto/index.js";
+import { authenticate } from "../middleware/authMiddleware.js";
+
+export const vaultRegistryRouter = Router();
+
+// ---------------------------------------------------------------------------
+// Validation schemas
+// ---------------------------------------------------------------------------
+
+const createVaultSchema = z.object({
+  contract_id: z.string().min(1).max(256),
+  name: z.string().min(1).max(128),
+  underlying_token: z.string().min(1).max(256),
+  network: z.enum(["testnet", "mainnet", "futurenet"]).optional().default("testnet"),
+  description: z.string().max(512).optional(),
+  is_default: z.boolean().optional().default(false),
+});
+
+const updateVaultSchema = z.object({
+  name: z.string().min(1).max(128).optional(),
+  underlying_token: z.string().min(1).max(256).optional(),
+  network: z.enum(["testnet", "mainnet", "futurenet"]).optional(),
+  description: z.string().max(512).optional(),
+  is_active: z.boolean().optional(),
+  is_default: z.boolean().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Public: list vaults
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/v1/vaults
+ * Returns all active vaults, optionally filtered by ?network=testnet|mainnet
+ */
+vaultRegistryRouter.get("/", async (req: Request, res: Response): Promise<void> => {
+  try {
+    const network = typeof req.query.network === "string" ? req.query.network : undefined;
+    const vaults = await listVaults(network);
+    res.json(successResponse(vaults));
+  } catch (err) {
+    console.error("[vaults/list]", err);
+    res.status(500).json(errorResponse("INTERNAL_ERROR", "Failed to list vaults"));
+  }
+});
+
+/**
+ * GET /api/v1/vaults/:id
+ * Returns a single vault by ID (including inactive, for admin visibility).
+ */
+vaultRegistryRouter.get("/:id", async (req: Request, res: Response): Promise<void> => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) {
+    res.status(400).json(errorResponse("INVALID_PARAM", "Invalid vault ID"));
+    return;
+  }
+
+  try {
+    const vault = await getVaultById(id);
+    if (!vault) {
+      res.status(404).json(errorResponse("NOT_FOUND", "Vault not found"));
+      return;
+    }
+    res.json(successResponse(vault));
+  } catch (err) {
+    console.error("[vaults/get]", err);
+    res.status(500).json(errorResponse("INTERNAL_ERROR", "Failed to retrieve vault"));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Admin: write operations (require authentication)
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /api/v1/vaults
+ * Register a new vault contract in the registry.
+ */
+vaultRegistryRouter.post("/", authenticate, async (req: Request, res: Response): Promise<void> => {
+  const parsed = createVaultSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid input"));
+    return;
+  }
+
+  try {
+    const vault = await createVault(parsed.data);
+    res.status(201).json(successResponse(vault));
+  } catch (err: unknown) {
+    // Unique constraint on contract_id
+    if (err instanceof Error && err.message.includes("unique")) {
+      res.status(409).json(errorResponse("CONFLICT", "A vault with this contract_id already exists"));
+      return;
+    }
+    console.error("[vaults/create]", err);
+    res.status(500).json(errorResponse("INTERNAL_ERROR", "Failed to register vault"));
+  }
+});
+
+/**
+ * PATCH /api/v1/vaults/:id
+ * Update vault metadata.
+ */
+vaultRegistryRouter.patch("/:id", authenticate, async (req: Request, res: Response): Promise<void> => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) {
+    res.status(400).json(errorResponse("INVALID_PARAM", "Invalid vault ID"));
+    return;
+  }
+
+  const parsed = updateVaultSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json(errorResponse("VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Invalid input"));
+    return;
+  }
+
+  try {
+    const vault = await updateVault(id, parsed.data);
+    if (!vault) {
+      res.status(404).json(errorResponse("NOT_FOUND", "Vault not found"));
+      return;
+    }
+    res.json(successResponse(vault));
+  } catch (err) {
+    console.error("[vaults/update]", err);
+    res.status(500).json(errorResponse("INTERNAL_ERROR", "Failed to update vault"));
+  }
+});
+
+/**
+ * DELETE /api/v1/vaults/:id
+ * Soft-deactivate a vault. Historical data is preserved.
+ */
+vaultRegistryRouter.delete("/:id", authenticate, async (req: Request, res: Response): Promise<void> => {
+  const id = parseInt(req.params.id, 10);
+  if (isNaN(id)) {
+    res.status(400).json(errorResponse("INVALID_PARAM", "Invalid vault ID"));
+    return;
+  }
+
+  try {
+    const vault = await deactivateVault(id);
+    if (!vault) {
+      res.status(404).json(errorResponse("NOT_FOUND", "Vault not found"));
+      return;
+    }
+    res.json(successResponse({ message: "Vault deactivated", vault }));
+  } catch (err) {
+    console.error("[vaults/deactivate]", err);
+    res.status(500).json(errorResponse("INTERNAL_ERROR", "Failed to deactivate vault"));
+  }
+});

--- a/backend/src/routes/vaultRoutes.ts
+++ b/backend/src/routes/vaultRoutes.ts
@@ -1,11 +1,11 @@
 /**
- * Vault Stats Route — Issue #466
+ * Vault Stats Route — Issue #466 + Issue #310 (multi-tenant)
  *
- * GET /api/v1/vault/stats
+ * GET /api/v1/vault/stats?vaultId=<id>
  *
- * Returns vault statistics with Redis caching. Cache misses fetch live data,
- * cache hits serve instantly (< 50 ms). Harvest events invalidate the cache.
- * Redis unavailability falls back gracefully to a direct contract call.
+ * Returns vault statistics with Redis caching. When vaultId is provided the
+ * cache is scoped to that vault's contract_id. Omitting vaultId falls back
+ * to the default vault for backwards compatibility.
  */
 
 import { Router, Request, Response } from "express";
@@ -13,6 +13,7 @@ import { cacheGet, cacheSet, cacheDel } from "../cache.js";
 import { getVaultStats, VaultStatsData } from "../services/vaultStatsService.js";
 import { getDbMetrics, getSlowQueryLog, dbMetricsPrometheusText } from "../services/dbMonitor.js";
 import { successResponse, errorResponse } from "../dto/index.js";
+import { resolveVault } from "../services/vaultRegistryService.js";
 
 export const VAULT_STATS_CACHE_NS = "vault:stats";
 export const VAULT_STATS_CACHE_KEY = "current";
@@ -27,24 +28,46 @@ export interface VaultStatsResponse extends VaultStatsData {
   cached: boolean;
   cache_age_secs: number | null;
   fetched_at: string;
+  vault_id?: number;
+  contract_id?: string;
 }
 
 export const vaultRouter = Router();
 
 /**
- * GET /api/v1/vault/stats
+ * GET /api/v1/vault/stats?vaultId=<id>
  * Serves vault stats from cache when available, otherwise fetches live data.
+ * When vaultId is omitted, the default vault is used (backwards compatible).
  */
-vaultRouter.get("/stats", async (_req: Request, res: Response): Promise<void> => {
+vaultRouter.get("/stats", async (req: Request, res: Response): Promise<void> => {
   const fetchedAt = new Date().toISOString();
+
+  // Resolve vault — backwards compatible: no vaultId → default vault
+  let vaultContractId: string | undefined;
+  let vaultId: number | undefined;
+
+  try {
+    const vaultIdParam = req.query.vaultId as string | undefined;
+    const vault = await resolveVault(vaultIdParam);
+    if (vaultIdParam && !vault) {
+      res.status(404).json(errorResponse("NOT_FOUND", "Vault not found"));
+      return;
+    }
+    vaultContractId = vault?.contract_id;
+    vaultId = vault?.id;
+  } catch {
+    // DB unavailable — continue without vault scoping (single-vault fallback)
+  }
+
+  // Scope cache key to vault contract_id when available
+  const scopedCacheKey = vaultContractId
+    ? `${VAULT_STATS_CACHE_KEY}:${vaultContractId}`
+    : VAULT_STATS_CACHE_KEY;
 
   // --- Try cache first ---
   let cacheEntry: VaultStatsCacheEntry | null = null;
   try {
-    cacheEntry = await cacheGet<VaultStatsCacheEntry>(
-      VAULT_STATS_CACHE_NS,
-      VAULT_STATS_CACHE_KEY,
-    );
+    cacheEntry = await cacheGet<VaultStatsCacheEntry>(VAULT_STATS_CACHE_NS, scopedCacheKey);
   } catch {
     // Redis unavailable — fall through to live fetch
   }
@@ -56,6 +79,8 @@ vaultRouter.get("/stats", async (_req: Request, res: Response): Promise<void> =>
       cached: true,
       cache_age_secs: Math.floor(ageMs / 1000),
       fetched_at: fetchedAt,
+      ...(vaultId && { vault_id: vaultId }),
+      ...(vaultContractId && { contract_id: vaultContractId }),
     };
     res.json(successResponse(payload));
     return;
@@ -68,7 +93,7 @@ vaultRouter.get("/stats", async (_req: Request, res: Response): Promise<void> =>
 
     // Populate cache (best-effort — ignore Redis errors)
     try {
-      await cacheSet(VAULT_STATS_CACHE_NS, VAULT_STATS_CACHE_KEY, entry, VAULT_STATS_TTL_SECS);
+      await cacheSet(VAULT_STATS_CACHE_NS, scopedCacheKey, entry, VAULT_STATS_TTL_SECS);
     } catch {
       // Redis unavailable — serve without caching
     }
@@ -78,6 +103,8 @@ vaultRouter.get("/stats", async (_req: Request, res: Response): Promise<void> =>
       cached: false,
       cache_age_secs: null,
       fetched_at: fetchedAt,
+      ...(vaultId && { vault_id: vaultId }),
+      ...(vaultContractId && { contract_id: vaultContractId }),
     };
     res.json(successResponse(payload));
   } catch (err) {
@@ -87,12 +114,22 @@ vaultRouter.get("/stats", async (_req: Request, res: Response): Promise<void> =>
 });
 
 /**
- * POST /api/v1/vault/stats/invalidate
- * Purges the vault-stats cache. Called when a harvest event is received.
+ * POST /api/v1/vault/stats/invalidate?vaultId=<id>
+ * Purges the vault-stats cache for a specific vault (or default if omitted).
  */
-vaultRouter.post("/stats/invalidate", async (_req: Request, res: Response): Promise<void> => {
+vaultRouter.post("/stats/invalidate", async (req: Request, res: Response): Promise<void> => {
   try {
-    await cacheDel(VAULT_STATS_CACHE_NS, VAULT_STATS_CACHE_KEY);
+    const vaultIdParam = req.query.vaultId as string | undefined;
+    let scopedCacheKey = VAULT_STATS_CACHE_KEY;
+
+    if (vaultIdParam) {
+      const vault = await resolveVault(vaultIdParam).catch(() => null);
+      if (vault?.contract_id) {
+        scopedCacheKey = `${VAULT_STATS_CACHE_KEY}:${vault.contract_id}`;
+      }
+    }
+
+    await cacheDel(VAULT_STATS_CACHE_NS, scopedCacheKey);
     res.json(successResponse({ invalidated: true }));
   } catch (err) {
     console.error("[vault/stats/invalidate]", err);
@@ -101,8 +138,9 @@ vaultRouter.post("/stats/invalidate", async (_req: Request, res: Response): Prom
 });
 
 /** Programmatic cache invalidation — used by harvest event handlers. */
-export async function invalidateVaultStatsCache(): Promise<void> {
-  await cacheDel(VAULT_STATS_CACHE_NS, VAULT_STATS_CACHE_KEY);
+export async function invalidateVaultStatsCache(contractId?: string): Promise<void> {
+  const key = contractId ? `${VAULT_STATS_CACHE_KEY}:${contractId}` : VAULT_STATS_CACHE_KEY;
+  await cacheDel(VAULT_STATS_CACHE_NS, key);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -140,7 +178,6 @@ vaultRouter.get("/metrics/db/slow-log", async (_req: Request, res: Response): Pr
 /**
  * GET /api/v1/vault/metrics/db/prometheus
  * Returns Prometheus text exposition for db_query_duration_seconds histogram.
- * Allows Prometheus to scrape this path directly if configured.
  */
 vaultRouter.get("/metrics/db/prometheus", async (_req: Request, res: Response): Promise<void> => {
   try {

--- a/backend/src/services/vaultRegistryService.ts
+++ b/backend/src/services/vaultRegistryService.ts
@@ -1,0 +1,235 @@
+/**
+ * Vault Registry Service — Issue #310
+ *
+ * Manages the registry of vault contract instances.
+ * Provides CRUD operations for vaults and resolution of the default vault
+ * for backwards-compatible API requests that omit vaultId.
+ */
+
+import { getWritePool, getReadPool } from "../db.js";
+import { cacheGet, cacheSet, cacheDel } from "../cache.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VaultRecord {
+  id: number;
+  contract_id: string;
+  name: string;
+  underlying_token: string;
+  network: string;
+  is_active: boolean;
+  is_default: boolean;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateVaultInput {
+  contract_id: string;
+  name: string;
+  underlying_token: string;
+  network?: string;
+  description?: string;
+  is_default?: boolean;
+}
+
+export interface UpdateVaultInput {
+  name?: string;
+  underlying_token?: string;
+  network?: string;
+  description?: string;
+  is_active?: boolean;
+  is_default?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Cache configuration
+// ---------------------------------------------------------------------------
+
+const VAULT_CACHE_NS = "vault:registry";
+const VAULT_LIST_KEY = "list:active";
+const VAULT_DEFAULT_KEY = "default";
+const VAULT_TTL_SECS = 300; // 5 minutes
+
+function vaultCacheKey(id: number | string): string {
+  return `id:${id}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function invalidateVaultCache(id?: number): Promise<void> {
+  await cacheDel(VAULT_CACHE_NS, VAULT_LIST_KEY);
+  await cacheDel(VAULT_CACHE_NS, VAULT_DEFAULT_KEY);
+  if (id !== undefined) {
+    await cacheDel(VAULT_CACHE_NS, vaultCacheKey(id));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * List all active vaults, optionally filtered by network.
+ */
+export async function listVaults(network?: string): Promise<VaultRecord[]> {
+  const cacheKey = `${VAULT_LIST_KEY}${network ? `:${network}` : ""}`;
+  const cached = await cacheGet<VaultRecord[]>(VAULT_CACHE_NS, cacheKey);
+  if (cached) return cached;
+
+  const db = getReadPool();
+  const params: unknown[] = [];
+  let sql = "SELECT * FROM vaults WHERE is_active = TRUE";
+  if (network) {
+    params.push(network);
+    sql += ` AND network = $${params.length}`;
+  }
+  sql += " ORDER BY is_default DESC, created_at ASC";
+
+  const { rows } = await db.query<VaultRecord>(sql, params);
+  await cacheSet(VAULT_CACHE_NS, cacheKey, rows, VAULT_TTL_SECS);
+  return rows;
+}
+
+/**
+ * Get a vault by its integer ID.
+ */
+export async function getVaultById(id: number): Promise<VaultRecord | null> {
+  const cached = await cacheGet<VaultRecord>(VAULT_CACHE_NS, vaultCacheKey(id));
+  if (cached) return cached;
+
+  const db = getReadPool();
+  const { rows } = await db.query<VaultRecord>(
+    "SELECT * FROM vaults WHERE id = $1",
+    [id]
+  );
+  const vault = rows[0] ?? null;
+  if (vault) await cacheSet(VAULT_CACHE_NS, vaultCacheKey(id), vault, VAULT_TTL_SECS);
+  return vault;
+}
+
+/**
+ * Get a vault by its contract address.
+ */
+export async function getVaultByContractId(contractId: string): Promise<VaultRecord | null> {
+  const db = getReadPool();
+  const { rows } = await db.query<VaultRecord>(
+    "SELECT * FROM vaults WHERE contract_id = $1",
+    [contractId]
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Get the default vault (backwards-compatible single-vault behaviour).
+ * Returns the vault marked is_default = TRUE, or the first active vault
+ * if none is explicitly marked as default.
+ */
+export async function getDefaultVault(): Promise<VaultRecord | null> {
+  const cached = await cacheGet<VaultRecord>(VAULT_CACHE_NS, VAULT_DEFAULT_KEY);
+  if (cached) return cached;
+
+  const db = getReadPool();
+  const { rows } = await db.query<VaultRecord>(
+    "SELECT * FROM vaults WHERE is_active = TRUE ORDER BY is_default DESC, created_at ASC LIMIT 1"
+  );
+  const vault = rows[0] ?? null;
+  if (vault) await cacheSet(VAULT_CACHE_NS, VAULT_DEFAULT_KEY, vault, VAULT_TTL_SECS);
+  return vault;
+}
+
+/**
+ * Resolve a vault from an optional vaultId query parameter.
+ * Falls back to the default vault when vaultId is not provided.
+ */
+export async function resolveVault(vaultId?: string | number): Promise<VaultRecord | null> {
+  if (vaultId === undefined || vaultId === null || vaultId === "") {
+    return getDefaultVault();
+  }
+  const id = typeof vaultId === "string" ? parseInt(vaultId, 10) : vaultId;
+  if (isNaN(id)) return null;
+  return getVaultById(id);
+}
+
+// ---------------------------------------------------------------------------
+// Mutations (admin operations)
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a new vault in the registry.
+ */
+export async function createVault(input: CreateVaultInput): Promise<VaultRecord> {
+  const db = getWritePool();
+
+  // If this vault is being set as default, unset the current default first
+  if (input.is_default) {
+    await db.query("UPDATE vaults SET is_default = FALSE WHERE is_default = TRUE");
+  }
+
+  const { rows } = await db.query<VaultRecord>(
+    `INSERT INTO vaults (contract_id, name, underlying_token, network, is_active, is_default, description)
+     VALUES ($1, $2, $3, $4, TRUE, $5, $6)
+     RETURNING *`,
+    [
+      input.contract_id,
+      input.name,
+      input.underlying_token,
+      input.network ?? "testnet",
+      input.is_default ?? false,
+      input.description ?? null,
+    ]
+  );
+
+  await invalidateVaultCache();
+  return rows[0]!;
+}
+
+/**
+ * Update vault metadata. Admin-only.
+ */
+export async function updateVault(id: number, input: UpdateVaultInput): Promise<VaultRecord | null> {
+  const db = getWritePool();
+
+  // If setting a new default, unset the current one
+  if (input.is_default) {
+    await db.query("UPDATE vaults SET is_default = FALSE WHERE is_default = TRUE AND id != $1", [id]);
+  }
+
+  const fields: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  const allowedFields: Array<keyof UpdateVaultInput> = [
+    "name", "underlying_token", "network", "description", "is_active", "is_default"
+  ];
+
+  for (const key of allowedFields) {
+    const val = input[key];
+    if (val !== undefined) {
+      fields.push(`${key} = $${idx++}`);
+      values.push(val);
+    }
+  }
+
+  if (fields.length === 0) return getVaultById(id);
+
+  values.push(id);
+  const { rows } = await db.query<VaultRecord>(
+    `UPDATE vaults SET ${fields.join(", ")} WHERE id = $${idx} RETURNING *`,
+    values
+  );
+
+  await invalidateVaultCache(id);
+  return rows[0] ?? null;
+}
+
+/**
+ * Deactivate a vault (soft-delete). Does not remove historical data.
+ */
+export async function deactivateVault(id: number): Promise<VaultRecord | null> {
+  return updateVault(id, { is_active: false });
+}


### PR DESCRIPTION
## Summary

Extends the backend to support multiple vault contract addresses via a vault registry, enabling the platform to serve several independent vaults. Fully backwards compatible — existing single-vault clients continue to work unchanged.

## What was implemented

### Database: vaults registry table
- Migration `010_create_vaults_registry.sql`: creates `vaults(id, contract_id, name, underlying_token, network, is_active, is_default)`
- Partial unique index ensures only one default vault at a time
- Trigger auto-updates `updated_at`
- Seeds the default vault for zero-downtime deployment

### Service: vaultRegistryService.ts
- `listVaults(network?)` — lists active vaults with optional network filter
- `getVaultById(id)` / `getVaultByContractId(contractId)` — look up individual vaults
- `getDefaultVault()` — returns the default vault for backwards compatibility
- `resolveVault(vaultId?)` — resolves optional vaultId param, falls back to default
- `createVault()` / `updateVault()` / `deactivateVault()` — admin mutations
- 5-minute Redis cache (vault:registry namespace) on all reads

### API endpoints
- `GET /api/v1/vaults` — list all active vaults (optionally `?network=testnet`)
- `GET /api/v1/vaults/:id` — get a single vault
- `POST /api/v1/vaults` — register new vault (auth required)
- `PATCH /api/v1/vaults/:id` — update vault metadata (auth required)
- `DELETE /api/v1/vaults/:id` — soft-deactivate vault (auth required)

### Backwards compatibility
- `GET /api/v1/vault/stats` now accepts optional `?vaultId=<id>`
- Omitting `vaultId` falls back to default vault — no breaking change
- Cache key scoped per `contract_id` when vaultId provided

## Files changed
- `backend/migrations/010_create_vaults_registry.sql`
- `backend/src/services/vaultRegistryService.ts`
- `backend/src/routes/vaultRegistryRoutes.ts`
- `backend/src/routes/vaultRoutes.ts`
- `backend/src/index.ts`

Closes #310