### PR TITLE
feat(cors): strict CORS headers with origin allowlist and per-route credentials

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,9 +4,13 @@ NODE_ENV=development
 AWS_REGION=us-east-1
 LOG_LEVEL=info
 
-# CORS — comma-separated list of allowed origins
+# CORS — comma-separated list of allowed origins (replaces/extends CORS_ORIGIN)
 # Production: set to your exact frontend domain(s)
-# e.g. CORS_ORIGIN=https://app.aura-vault.xyz,https://staging.aura-vault.xyz
+# e.g. CORS_ORIGINS=https://app.aura-vault.xyz,https://staging.aura-vault.xyz
+# Leave unset in development to allow localhost automatically.
+# Never use CORS_ORIGINS=* in production — it will be ignored and deny-all applied.
+CORS_ORIGINS=
+# Legacy single-origin fallback (CORS_ORIGINS takes precedence when set)
 CORS_ORIGIN=
 
 # Secrets

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import cors from "cors";
 import { authenticate } from "./middleware/authMiddleware.js";
 import {
   authRateLimiter,
@@ -34,10 +33,11 @@ import { startYieldWorker, stopYieldWorker } from "./services/yieldWorker.js";
 import { vaultRouter } from "./routes/vaultRoutes.js";
 import { userPreferencesRouter } from "./routes/userPreferencesRoutes.js";
 import { leaderboardRouter } from "./routes/leaderboardRoutes.js";
+import { applySecurityHeaders } from "./middleware/securityMiddleware.js";
 import {
-  applySecurityHeaders,
-  corsOptions,
-} from "./middleware/securityMiddleware.js";
+  createCorsMiddleware,
+  corsPreflightHandler,
+} from "./middleware/corsMiddleware.js";
 import {
   correlationIdMiddleware,
   createRequestLogger,
@@ -49,7 +49,10 @@ import {
 } from "./validation.js";
 
 const app = express();
-app.use(cors());
+
+// ── A05 Security Misconfiguration: handle CORS preflight before any auth/rate-limit ──
+app.options(/.*/, corsPreflightHandler());
+
 app.use(express.json());
 app.use(loggingMiddleware());
 app.use(globalIpRateLimiter(["/api/health"]));
@@ -58,8 +61,8 @@ app.use(globalIpRateLimiter(["/api/health"]));
 applySecurityHeaders(app);
 
 // ── A05 Security Misconfiguration: strict CORS ───────────────────────────────
-// Replace the open cors() with allowlist-driven corsOptions
-app.use(cors(corsOptions));
+// Per-request CORS: credentials enabled only for /api/auth/* routes
+app.use(createCorsMiddleware());
 
 // ── A09 Logging Failures: correlation IDs + structured request logging ────────
 app.use(correlationIdMiddleware());

--- a/backend/src/middleware/__tests__/corsMiddleware.test.ts
+++ b/backend/src/middleware/__tests__/corsMiddleware.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Unit tests for CORS middleware — Issue #297
+ *
+ * Verifies:
+ *  - buildAllowedOrigins() parses CORS_ORIGINS correctly
+ *  - Wildcard/empty origins denied in production, allowed in dev
+ *  - Listed origins are allowed; unlisted origins are rejected
+ *  - Preflight OPTIONS requests return 204 with correct headers
+ *  - Credentials header is set for /api/auth/* routes only
+ *  - No Origin header is handled correctly per environment
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express, { type Application } from 'express';
+import request from 'supertest';
+import {
+  buildAllowedOrigins,
+  createCorsMiddleware,
+  corsPreflightHandler,
+} from '../../middleware/corsMiddleware.js';
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeApp(): Application {
+  const app = express();
+  // Express v5 path-to-regexp is strict — use a regex for catch-all OPTIONS
+  app.options(/.*/, corsPreflightHandler());
+  app.use(createCorsMiddleware());
+  app.get('/test', (_req, res) => res.json({ ok: true }));
+  app.post('/api/auth/login', (_req, res) => res.json({ ok: true }));
+  app.get('/api/v1/vault/stats', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+// ─── buildAllowedOrigins ──────────────────────────────────────────────────────
+
+describe('buildAllowedOrigins()', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      NODE_ENV: process.env.NODE_ENV,
+      CORS_ORIGINS: process.env.CORS_ORIGINS,
+      CORS_ORIGIN: process.env.CORS_ORIGIN,
+    };
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedEnv.NODE_ENV;
+    if (savedEnv.CORS_ORIGINS === undefined) {
+      delete process.env.CORS_ORIGINS;
+    } else {
+      process.env.CORS_ORIGINS = savedEnv.CORS_ORIGINS;
+    }
+    if (savedEnv.CORS_ORIGIN === undefined) {
+      delete process.env.CORS_ORIGIN;
+    } else {
+      process.env.CORS_ORIGIN = savedEnv.CORS_ORIGIN;
+    }
+  });
+
+  it('returns localhost regexes in development when CORS_ORIGINS is unset', () => {
+    delete process.env.CORS_ORIGINS;
+    delete process.env.CORS_ORIGIN;
+    process.env.NODE_ENV = 'development';
+    const origins = buildAllowedOrigins();
+    expect(origins).toHaveLength(2);
+    expect(origins[0]).toBeInstanceOf(RegExp);
+    expect(origins[1]).toBeInstanceOf(RegExp);
+  });
+
+  it('returns empty array in production when CORS_ORIGINS is unset', () => {
+    delete process.env.CORS_ORIGINS;
+    delete process.env.CORS_ORIGIN;
+    process.env.NODE_ENV = 'production';
+    const origins = buildAllowedOrigins();
+    expect(origins).toHaveLength(0);
+  });
+
+  it('returns empty array in production when CORS_ORIGINS is wildcard (*)', () => {
+    process.env.CORS_ORIGINS = '*';
+    process.env.NODE_ENV = 'production';
+    const origins = buildAllowedOrigins();
+    expect(origins).toHaveLength(0);
+  });
+
+  it('parses a single origin correctly', () => {
+    process.env.CORS_ORIGINS = 'https://app.aura-vault.xyz';
+    process.env.NODE_ENV = 'production';
+    const origins = buildAllowedOrigins();
+    expect(origins).toEqual(['https://app.aura-vault.xyz']);
+  });
+
+  it('parses multiple comma-separated origins', () => {
+    process.env.CORS_ORIGINS =
+      'https://app.aura-vault.xyz,https://staging.aura-vault.xyz';
+    process.env.NODE_ENV = 'production';
+    const origins = buildAllowedOrigins();
+    expect(origins).toEqual([
+      'https://app.aura-vault.xyz',
+      'https://staging.aura-vault.xyz',
+    ]);
+  });
+
+  it('trims whitespace around origins', () => {
+    process.env.CORS_ORIGINS =
+      ' https://app.aura-vault.xyz , https://staging.aura-vault.xyz ';
+    const origins = buildAllowedOrigins();
+    expect(origins).toEqual([
+      'https://app.aura-vault.xyz',
+      'https://staging.aura-vault.xyz',
+    ]);
+  });
+
+  it('reads from CORS_ORIGIN as fallback when CORS_ORIGINS is absent', () => {
+    delete process.env.CORS_ORIGINS;
+    process.env.CORS_ORIGIN = 'https://fallback.aura-vault.xyz';
+    process.env.NODE_ENV = 'production';
+    const origins = buildAllowedOrigins();
+    expect(origins).toEqual(['https://fallback.aura-vault.xyz']);
+  });
+});
+
+// ─── Allowed origins ──────────────────────────────────────────────────────────
+
+describe('CORS — allowed origins', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      NODE_ENV: process.env.NODE_ENV,
+      CORS_ORIGINS: process.env.CORS_ORIGINS,
+    };
+    process.env.CORS_ORIGINS =
+      'https://app.aura-vault.xyz,https://staging.aura-vault.xyz';
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedEnv.NODE_ENV;
+    if (savedEnv.CORS_ORIGINS === undefined) {
+      delete process.env.CORS_ORIGINS;
+    } else {
+      process.env.CORS_ORIGINS = savedEnv.CORS_ORIGINS;
+    }
+  });
+
+  it('allows a listed origin', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/test')
+      .set('Origin', 'https://app.aura-vault.xyz');
+    expect(res.status).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe(
+      'https://app.aura-vault.xyz'
+    );
+  });
+
+  it('rejects an unlisted origin — no ACAO header returned', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/test')
+      .set('Origin', 'https://evil.example.com');
+    // cors package responds with 500 when origin is rejected via Error callback
+    expect([403, 500]).toContain(res.status);
+    expect(res.headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('allows a second listed origin', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/test')
+      .set('Origin', 'https://staging.aura-vault.xyz');
+    expect(res.status).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe(
+      'https://staging.aura-vault.xyz'
+    );
+  });
+});
+
+// ─── Preflight requests ───────────────────────────────────────────────────────
+
+describe('CORS — preflight OPTIONS requests', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      NODE_ENV: process.env.NODE_ENV,
+      CORS_ORIGINS: process.env.CORS_ORIGINS,
+    };
+    process.env.CORS_ORIGINS = 'https://app.aura-vault.xyz';
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedEnv.NODE_ENV;
+    if (savedEnv.CORS_ORIGINS === undefined) {
+      delete process.env.CORS_ORIGINS;
+    } else {
+      process.env.CORS_ORIGINS = savedEnv.CORS_ORIGINS;
+    }
+  });
+
+  it('returns 204 for preflight from an allowed origin', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .options('/test')
+      .set('Origin', 'https://app.aura-vault.xyz')
+      .set('Access-Control-Request-Method', 'GET');
+    expect(res.status).toBe(204);
+  });
+
+  it('includes Access-Control-Allow-Methods in preflight response', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .options('/test')
+      .set('Origin', 'https://app.aura-vault.xyz')
+      .set('Access-Control-Request-Method', 'POST');
+    expect(res.headers['access-control-allow-methods']).toMatch(/POST/i);
+  });
+
+  it('includes Access-Control-Allow-Headers in preflight response', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .options('/test')
+      .set('Origin', 'https://app.aura-vault.xyz')
+      .set('Access-Control-Request-Headers', 'Authorization');
+    expect(res.headers['access-control-allow-headers']).toMatch(/Authorization/i);
+  });
+
+  it('includes Access-Control-Max-Age in preflight response', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .options('/test')
+      .set('Origin', 'https://app.aura-vault.xyz')
+      .set('Access-Control-Request-Method', 'GET');
+    expect(res.headers['access-control-max-age']).toBe('86400');
+  });
+});
+
+// ─── Credentials scoping ──────────────────────────────────────────────────────
+
+describe('CORS — credentials allowed only on auth routes', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      NODE_ENV: process.env.NODE_ENV,
+      CORS_ORIGINS: process.env.CORS_ORIGINS,
+    };
+    process.env.CORS_ORIGINS = 'https://app.aura-vault.xyz';
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedEnv.NODE_ENV;
+    if (savedEnv.CORS_ORIGINS === undefined) {
+      delete process.env.CORS_ORIGINS;
+    } else {
+      process.env.CORS_ORIGINS = savedEnv.CORS_ORIGINS;
+    }
+  });
+
+  it('sets Access-Control-Allow-Credentials: true on /api/auth/* routes', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post('/api/auth/login')
+      .set('Origin', 'https://app.aura-vault.xyz');
+    expect(res.headers['access-control-allow-credentials']).toBe('true');
+  });
+
+  it('does NOT set Access-Control-Allow-Credentials on non-auth routes', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/api/v1/vault/stats')
+      .set('Origin', 'https://app.aura-vault.xyz');
+    expect(res.headers['access-control-allow-credentials']).toBeUndefined();
+  });
+});
+
+// ─── No-Origin header (server-to-server) ─────────────────────────────────────
+
+describe('CORS — requests without Origin header', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      NODE_ENV: process.env.NODE_ENV,
+      CORS_ORIGINS: process.env.CORS_ORIGINS,
+    };
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedEnv.NODE_ENV;
+    if (savedEnv.CORS_ORIGINS === undefined) {
+      delete process.env.CORS_ORIGINS;
+    } else {
+      process.env.CORS_ORIGINS = savedEnv.CORS_ORIGINS;
+    }
+  });
+
+  it('allows no-origin requests in development', async () => {
+    process.env.CORS_ORIGINS = 'https://app.aura-vault.xyz';
+    process.env.NODE_ENV = 'development';
+    const app = makeApp();
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+  });
+
+  it('allows no-origin requests in test environment', async () => {
+    process.env.CORS_ORIGINS = 'https://app.aura-vault.xyz';
+    process.env.NODE_ENV = 'test';
+    const app = makeApp();
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─── Exposed headers ─────────────────────────────────────────────────────────
+
+describe('CORS — exposed headers', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {
+      NODE_ENV: process.env.NODE_ENV,
+      CORS_ORIGINS: process.env.CORS_ORIGINS,
+    };
+    process.env.CORS_ORIGINS = 'https://app.aura-vault.xyz';
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedEnv.NODE_ENV;
+    if (savedEnv.CORS_ORIGINS === undefined) {
+      delete process.env.CORS_ORIGINS;
+    } else {
+      process.env.CORS_ORIGINS = savedEnv.CORS_ORIGINS;
+    }
+  });
+
+  it('exposes X-Correlation-ID to browser clients', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/test')
+      .set('Origin', 'https://app.aura-vault.xyz');
+    expect(res.headers['access-control-expose-headers']).toMatch(
+      /X-Correlation-ID/i
+    );
+  });
+});

--- a/backend/src/middleware/corsMiddleware.ts
+++ b/backend/src/middleware/corsMiddleware.ts
@@ -1,0 +1,189 @@
+/**
+ * Strict CORS middleware — Issue #297
+ *
+ * Loads allowed origins from the CORS_ORIGINS environment variable
+ * (comma-separated list) and builds a per-request origin check that:
+ *
+ *  - Allows only explicitly listed origins in production
+ *  - Falls back to localhost patterns in development when CORS_ORIGINS is unset
+ *  - Rejects wildcard (*) in production to prevent accidental open policies
+ *  - Enables credentials only on /api/auth/* routes (cookie / Authorization header)
+ *  - Handles preflight OPTIONS requests correctly (204, no body)
+ *  - Exposes X-Correlation-ID to browser clients
+ *
+ * USAGE
+ *   import { createCorsMiddleware, corsPreflightHandler } from './corsMiddleware.js';
+ *   app.use(corsPreflightHandler());
+ *   app.use(createCorsMiddleware());
+ *
+ * ENV
+ *   CORS_ORIGINS — comma-separated allowed origins, e.g.:
+ *     CORS_ORIGINS=https://app.aura-vault.xyz,https://staging.aura-vault.xyz
+ */
+
+import cors, { type CorsOptions } from 'cors';
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Routes where credentials (cookies / Authorization) are permitted. */
+const AUTH_ROUTE_PREFIXES = ['/api/auth'];
+
+/** Headers browsers may send to the backend. */
+const ALLOWED_HEADERS = [
+  'Authorization',
+  'Content-Type',
+  'X-Correlation-ID',
+  'X-Request-ID',
+];
+
+/** Headers browsers may read from the response. */
+const EXPOSED_HEADERS = ['X-Correlation-ID'];
+
+/** How long browsers cache the preflight response (24 h). */
+const PREFLIGHT_MAX_AGE = 86_400;
+
+// ─── Origin list builder ──────────────────────────────────────────────────────
+
+/**
+ * Parse the CORS_ORIGINS environment variable into a list of allowed origins.
+ *
+ * Rules:
+ *  - Production + empty/wildcard → deny all (return empty list)
+ *  - Development + empty/wildcard → allow localhost patterns
+ *  - Otherwise → parse comma-separated strings as exact-match origins
+ */
+export function buildAllowedOrigins(): (string | RegExp)[] {
+  const raw = (process.env.CORS_ORIGINS ?? process.env.CORS_ORIGIN ?? '').trim();
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (raw === '' || raw === '*') {
+    if (isProduction) {
+      console.warn(
+        '[cors] CORS_ORIGINS is not set (or is "*") in production — ' +
+        'defaulting to deny-all. Set CORS_ORIGINS to your frontend domain(s).'
+      );
+      return [];
+    }
+    // Development / test: allow any localhost port
+    return [
+      /^https?:\/\/localhost(:\d+)?$/,
+      /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
+    ];
+  }
+
+  return raw
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+}
+
+// ─── Origin callback ──────────────────────────────────────────────────────────
+
+/**
+ * CORS origin callback used by the `cors` npm package.
+ *
+ * Server-to-server requests without an Origin header are allowed in
+ * non-production environments (e.g. CLI tools, Postman, integration tests).
+ * In production they are rejected to prevent misconfigured callers.
+ */
+function originCallback(
+  origin: string | undefined,
+  callback: (err: Error | null, allow?: boolean) => void
+): void {
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (!origin) {
+    // No Origin header (same-origin request, server-side caller, or curl)
+    callback(null, !isProduction);
+    return;
+  }
+
+  const allowed = buildAllowedOrigins();
+
+  const isAllowed = allowed.some((pattern) =>
+    typeof pattern === 'string'
+      ? pattern === origin
+      : pattern.test(origin)
+  );
+
+  if (isAllowed) {
+    callback(null, true);
+  } else {
+    callback(
+      new Error(`Origin "${origin}" is not permitted by the CORS policy`)
+    );
+  }
+}
+
+// ─── Per-request credentials check ───────────────────────────────────────────
+
+/**
+ * Build a CorsOptions object for the given request.
+ *
+ * Credentials (cookies, Authorization headers) are only enabled for auth
+ * routes so other public endpoints do not unnecessarily allow cross-origin
+ * cookies, reducing the risk of CSRF on endpoints that serve public data.
+ */
+function buildCorsOptions(req: Request): CorsOptions {
+  const isAuthRoute = AUTH_ROUTE_PREFIXES.some((prefix) =>
+    req.path.startsWith(prefix)
+  );
+
+  return {
+    origin: originCallback,
+    credentials: isAuthRoute,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ALLOWED_HEADERS,
+    exposedHeaders: EXPOSED_HEADERS,
+    maxAge: PREFLIGHT_MAX_AGE,
+    optionsSuccessStatus: 204,
+  };
+}
+
+// ─── Middleware factories ─────────────────────────────────────────────────────
+
+/**
+ * Creates the main CORS middleware with per-request credential scoping.
+ *
+ * Mount this after your security-headers middleware and before your routes.
+ */
+export function createCorsMiddleware(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    cors(buildCorsOptions(req))(req, res, next);
+  };
+}
+
+/**
+ * Preflight handler — answers OPTIONS requests immediately with 204.
+ *
+ * Must be mounted BEFORE route handlers so preflight requests are not
+ * caught by auth middleware or rate limiters.
+ *
+ * Mount at the top of the Express middleware stack:
+ *   app.options('*', corsPreflightHandler());
+ */
+export function corsPreflightHandler(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (req.method !== 'OPTIONS') {
+      next();
+      return;
+    }
+    cors(buildCorsOptions(req))(req, res, next);
+  };
+}
+
+/**
+ * Convenience export: pre-built CorsOptions for the common case where
+ * per-request credential scoping is not needed (e.g. unit tests, static
+ * analysis of the config shape).
+ */
+export const defaultCorsOptions: CorsOptions = {
+  origin: originCallback,
+  credentials: false,
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ALLOWED_HEADERS,
+  exposedHeaders: EXPOSED_HEADERS,
+  maxAge: PREFLIGHT_MAX_AGE,
+  optionsSuccessStatus: 204,
+};


### PR DESCRIPTION
## Summary

Configures strict CORS headers so only trusted frontend origins can call the backend API, with credentials scoped only to authentication routes.

## What was implemented

- **`corsMiddleware.ts`** — new dedicated CORS middleware replacing the previous open `cors()` call
- **`CORS_ORIGINS` env var** — comma-separated list of allowed origins (e.g. `https://app.aura-vault.xyz,https://staging.aura-vault.xyz`); falls back to legacy `CORS_ORIGIN` when `CORS_ORIGINS` is unset
- **No wildcard in production** — `CORS_ORIGINS=*` (or empty) in `NODE_ENV=production` logs a warning and defaults to deny-all
- **Development fallback** — localhost and 127.0.0.1 on any port allowed automatically when `CORS_ORIGINS` is unset in dev
- **Credentials scoped to auth routes** — `Access-Control-Allow-Credentials: true` is set only for `/api/auth/*` requests; all other routes withhold it to reduce CSRF surface
- **Preflight OPTIONS handled** — `corsPreflightHandler()` mounted before auth/rate-limit middleware responds to `OPTIONS` with 204 and correct preflight headers
- **`Access-Control-Max-Age: 86400`** — browsers cache preflight for 24 h
- **`X-Correlation-ID` exposed** — browsers can read the correlation ID for client-side logging
- **`index.ts` updated** — removed open `cors()`, mounted `app.options(/.*/, corsPreflightHandler())` first, then `app.use(createCorsMiddleware())`
- **`.env.example` updated** — documents `CORS_ORIGINS` with examples and production guidance
- **19 Vitest unit tests** — covering origin allowlist parsing, allowed/rejected origins, preflight headers, credentials scoping, no-Origin handling, and exposed headers

## What was tested

- All 19 new CORS unit tests pass (verified locally: `npx vitest run src/middleware/__tests__/corsMiddleware.test.ts`)
- Pre-existing test failures (vaultStats, apyRoutes, gdprRoutes) are unrelated to this change and exist on main

Closes #297