### PR TITLE
feat(backend): implement idempotency keys for transaction endpoints (#307)

### DIFF
--- a/backend/src/middleware/idempotencyMiddleware.ts
+++ b/backend/src/middleware/idempotencyMiddleware.ts
@@ -1,0 +1,105 @@
+/**
+ * idempotencyMiddleware.ts — Express middleware for API transaction idempotency.
+ *
+ * Implements safe network retries using the `Idempotency-Key` header:
+ *   1. Accepts `Idempotency-Key` header (must be a valid UUID).
+ *   2. Rejects invalid UUID formats with 400 Bad Request.
+ *   3. Checks Redis for an existing record with 24-hour TTL (86,400s).
+ *   4. If key exists with the SAME request payload hash, returns the cached response (no re-execution).
+ *   5. If key exists with a DIFFERENT request payload hash, rejects with 400 Bad Request.
+ *   6. On first execution, caches the successful response in Redis with a 24-hour TTL.
+ */
+
+import { Request, Response, NextFunction, RequestHandler } from "express";
+import crypto from "crypto";
+import { getRedis } from "../redis.js";
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60; // 24 hours
+
+interface CachedIdempotencyRecord {
+  requestHash: string;
+  statusCode: number;
+  body: unknown;
+  headers?: Record<string, string>;
+}
+
+export function idempotency(): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const rawKey = req.header("Idempotency-Key") || req.header("idempotency-key") || req.header("x-idempotency-key");
+
+    // If no idempotency key header provided, pass through
+    if (!rawKey) {
+      return next();
+    }
+
+    const key = Array.isArray(rawKey) ? rawKey[0].trim() : rawKey.trim();
+
+    // Validate UUID format server-side
+    if (!UUID_REGEX.test(key)) {
+      res.status(400).json({
+        error: "Idempotency-Key must be a valid UUID",
+        code: "INVALID_IDEMPOTENCY_KEY",
+      });
+      return;
+    }
+
+    // Deterministic payload hash for collision/reuse detection
+    const payloadString = JSON.stringify(req.body ?? {});
+    const requestHash = crypto.createHash("sha256").update(payloadString).digest("hex");
+    const redisKey = `idempotency:${key}`;
+
+    try {
+      const redis = getRedis();
+      const cachedData = await redis.get(redisKey);
+
+      if (cachedData) {
+        const record: CachedIdempotencyRecord = JSON.parse(cachedData);
+
+        // Check if key is reused with a different request payload
+        if (record.requestHash !== requestHash) {
+          res.status(400).json({
+            error: "Idempotency key reused with different request payload",
+            code: "IDEMPOTENCY_KEY_PAYLOAD_MISMATCH",
+          });
+          return;
+        }
+
+        // Return cached response without re-executing
+        res.setHeader("X-Idempotent-Replay", "true");
+        res.status(record.statusCode).json(record.body);
+        return;
+      }
+    } catch (err) {
+      console.warn("[idempotency] Redis error during lookup, proceeding without cache:", err);
+    }
+
+    // Intercept response to cache on completion
+    const originalJson = res.json.bind(res);
+    res.json = (body: unknown): Response => {
+      // Restore original res.json
+      res.json = originalJson;
+
+      // Only cache successful or intentional responses
+      if (res.statusCode >= 200 && res.statusCode < 500) {
+        try {
+          const redis = getRedis();
+          const record: CachedIdempotencyRecord = {
+            requestHash,
+            statusCode: res.statusCode,
+            body,
+          };
+          redis.set(redisKey, JSON.stringify(record), "EX", IDEMPOTENCY_TTL_SECONDS).catch((err) => {
+            console.warn("[idempotency] Failed to cache response in Redis:", err);
+          });
+        } catch (err) {
+          console.warn("[idempotency] Redis client error during caching:", err);
+        }
+      }
+
+      return originalJson(body);
+    };
+
+    next();
+  };
+}

--- a/backend/src/routes/__tests__/idempotency.test.ts
+++ b/backend/src/routes/__tests__/idempotency.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import express, { Request, Response } from "express";
+import request from "supertest";
+import { idempotency } from "../../middleware/idempotencyMiddleware.js";
+
+const redisStore = new Map<string, string>();
+
+vi.mock("../../redis.js", () => ({
+  getRedis: () => ({
+    get: vi.fn(async (key: string) => redisStore.get(key) ?? null),
+    set: vi.fn(async (key: string, val: string) => {
+      redisStore.set(key, val);
+      return "OK";
+    }),
+  }),
+}));
+
+describe("Idempotency Middleware (Issue #307)", () => {
+  let app: express.Express;
+  let executionCount = 0;
+
+  beforeEach(() => {
+    redisStore.clear();
+    executionCount = 0;
+
+    app = express();
+    app.use(express.json());
+    app.post("/test-tx", idempotency(), (req: Request, res: Response) => {
+      executionCount++;
+      res.status(200).json({
+        success: true,
+        data: req.body,
+        count: executionCount,
+      });
+    });
+  });
+
+  it("passes through normally when no Idempotency-Key header is provided", async () => {
+    const res1 = await request(app).post("/test-tx").send({ amount: "100" });
+    expect(res1.status).toBe(200);
+    expect(res1.body.count).toBe(1);
+
+    const res2 = await request(app).post("/test-tx").send({ amount: "100" });
+    expect(res2.status).toBe(200);
+    expect(res2.body.count).toBe(2);
+  });
+
+  it("rejects non-UUID idempotency key with 400 Bad Request", async () => {
+    const res = await request(app)
+      .post("/test-tx")
+      .set("Idempotency-Key", "not-a-uuid-1234")
+      .send({ amount: "100" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_IDEMPOTENCY_KEY");
+    expect(executionCount).toBe(0);
+  });
+
+  it("caches response on first request and replays it on second request without re-execution", async () => {
+    const key = "e8293992-1e94-4d8b-967a-555e1c4a0342";
+
+    // Request 1
+    const res1 = await request(app)
+      .post("/test-tx")
+      .set("Idempotency-Key", key)
+      .send({ amount: "500", address: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI" });
+
+    expect(res1.status).toBe(200);
+    expect(res1.body.count).toBe(1);
+    expect(executionCount).toBe(1);
+
+    // Request 2 (identical key & body)
+    const res2 = await request(app)
+      .post("/test-tx")
+      .set("Idempotency-Key", key)
+      .send({ amount: "500", address: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI" });
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.count).toBe(1); // Cached value returned
+    expect(res2.headers["x-idempotent-replay"]).toBe("true");
+    expect(executionCount).toBe(1); // Handler was not re-executed!
+  });
+
+  it("rejects request with 400 if idempotency key is reused with different payload", async () => {
+    const key = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+
+    // Request 1
+    const res1 = await request(app)
+      .post("/test-tx")
+      .set("Idempotency-Key", key)
+      .send({ amount: "100" });
+
+    expect(res1.status).toBe(200);
+    expect(executionCount).toBe(1);
+
+    // Request 2 (same key, different body)
+    const res2 = await request(app)
+      .post("/test-tx")
+      .set("Idempotency-Key", key)
+      .send({ amount: "200" });
+
+    expect(res2.status).toBe(400);
+    expect(res2.body.code).toBe("IDEMPOTENCY_KEY_PAYLOAD_MISMATCH");
+    expect(executionCount).toBe(1);
+  });
+});

--- a/backend/src/routes/vaultTransactionRoutes.ts
+++ b/backend/src/routes/vaultTransactionRoutes.ts
@@ -17,6 +17,7 @@ import { Router, Request, Response } from "express";
 import { authenticate } from "../middleware/authMiddleware.js";
 import { userRateLimiter } from "../middleware/rateLimitMiddleware.js";
 import { validateXdr } from "../middleware/validateXdrMiddleware.js";
+import { idempotency } from "../middleware/idempotencyMiddleware.js";
 import {
   submitTransaction,
   XdrValidationError,
@@ -62,6 +63,7 @@ vaultTransactionRouter.post(
   "/deposit",
   authenticate,
   userRateLimiter(),
+  idempotency(),
   validateXdr(),
   async (req: Request, res: Response): Promise<void> => {
     const { signedXdr, address } = req.body as {
@@ -111,6 +113,7 @@ vaultTransactionRouter.post(
   "/withdraw",
   authenticate,
   userRateLimiter(),
+  idempotency(),
   validateXdr(),
   async (req: Request, res: Response): Promise<void> => {
     const { signedXdr, shares, address } = req.body as {
@@ -175,6 +178,7 @@ vaultTransactionRouter.post(
   "/harvest",
   authenticate,
   userRateLimiter(),
+  idempotency(),
   validateXdr(),
   async (req: Request, res: Response): Promise<void> => {
     const { signedXdr, yieldAmount } = req.body as {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -239,6 +239,178 @@ paths:
                 timestamp: "2026-06-25T13:00:00.000Z"
 
   # ---------------------------------------------------------------------------
+  # Vault Transactions (with Idempotency Support)
+  # ---------------------------------------------------------------------------
+  /api/v1/vault/deposit:
+    post:
+      tags: [Vault]
+      summary: Submit a signed deposit transaction
+      description: |
+        Submits a signed Soroban deposit transaction envelope to Horizon.
+        Supports `Idempotency-Key` header (UUID) for safe network retries.
+      operationId: submitDeposit
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Optional UUID idempotency key for safe retries (cached for 24 hours in Redis).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [signedXdr, address]
+              properties:
+                signedXdr:
+                  type: string
+                  description: Base64-encoded signed Stellar TransactionEnvelope XDR.
+                address:
+                  type: string
+                  example: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI"
+      responses:
+        "200":
+          description: Deposit submitted successfully
+          headers:
+            X-Idempotent-Replay:
+              schema: { type: string }
+              description: Set to "true" if the response was served from the idempotency cache.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, example: true }
+                  operation: { type: string, example: "deposit" }
+                  address: { type: string }
+                  hash: { type: string }
+                  ledger: { type: integer }
+                  envelopeXdr: { type: string }
+                  resultXdr: { type: string }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          description: Horizon transaction failed
+
+  /api/v1/vault/withdraw:
+    post:
+      tags: [Vault]
+      summary: Submit a signed withdraw transaction
+      description: |
+        Submits a signed Soroban withdraw transaction envelope to Horizon.
+        Supports `Idempotency-Key` header (UUID) for safe network retries.
+      operationId: submitWithdraw
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Optional UUID idempotency key for safe retries (cached for 24 hours in Redis).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [signedXdr, shares, address]
+              properties:
+                signedXdr:
+                  type: string
+                shares:
+                  type: string
+                  example: "1000"
+                address:
+                  type: string
+      responses:
+        "200":
+          description: Withdrawal submitted successfully
+          headers:
+            X-Idempotent-Replay:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, example: true }
+                  operation: { type: string, example: "withdraw" }
+                  address: { type: string }
+                  shares: { type: string }
+                  hash: { type: string }
+                  ledger: { type: integer }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          description: Horizon transaction failed
+
+  /api/v1/vault/harvest:
+    post:
+      tags: [Vault]
+      summary: Submit a signed harvest transaction
+      description: |
+        Submits a signed Soroban harvest transaction envelope to Horizon.
+        Supports `Idempotency-Key` header (UUID) for safe network retries.
+      operationId: submitHarvest
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Optional UUID idempotency key for safe retries (cached for 24 hours in Redis).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [signedXdr, yieldAmount]
+              properties:
+                signedXdr:
+                  type: string
+                yieldAmount:
+                  type: string
+                  example: "500"
+      responses:
+        "200":
+          description: Harvest submitted successfully
+          headers:
+            X-Idempotent-Replay:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, example: true }
+                  operation: { type: string, example: "harvest" }
+                  yieldAmount: { type: string }
+                  hash: { type: string }
+                  ledger: { type: integer }
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          description: Horizon transaction failed
+
+  # ---------------------------------------------------------------------------
   # Portfolio
   # ---------------------------------------------------------------------------
   /api/v1/user/portfolio:


### PR DESCRIPTION
### Summary
Prevent duplicate contract invocations on network retry by supporting Idempotency-Key headers on all transaction endpoints.

### Changes Implemented
- Created `backend/src/middleware/idempotencyMiddleware.ts` Express middleware.
- Validates that `Idempotency-Key` is a valid UUID server-side (returns 400 with `INVALID_IDEMPOTENCY_KEY` if invalid).
- Computes deterministic SHA-256 hash of the request payload and caches successful responses in Redis with a 24-hour TTL (86,400s).
- On subsequent requests with the same key and payload, returns the cached response with `X-Idempotent-Replay: true` header without re-submitting to the network.
- Detects key reuse with conflicting request payloads and rejects with 400 Bad Request (`IDEMPOTENCY_KEY_PAYLOAD_MISMATCH`).
- Attached idempotency middleware to `/deposit`, `/withdraw`, and `/harvest` in `backend/src/routes/vaultTransactionRoutes.ts`.
- Added automated unit test suite in `backend/src/routes/__tests__/idempotency.test.ts`.
- Updated OpenAPI specification in `docs/openapi.yaml`.

closes #307